### PR TITLE
Show disabled 'create new image' button on failure

### DIFF
--- a/src/components/AvailableImagesTile.js
+++ b/src/components/AvailableImagesTile.js
@@ -50,6 +50,11 @@ const AvailableImageTile = () => {
     return (
       <AvailableImageTileBase>
         <CardBody>{data}</CardBody>
+        <CardFooter>
+          <Button isDisabled variant="primary">
+            Create new image
+          </Button>
+        </CardFooter>
       </AvailableImageTileBase>
     );
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2453279/116531673-1b5eaa80-a8e8-11eb-8d71-675dbcc8d914.png)

As discussed yesterday, make the "create new image" button disabled instead of hiding it.