### PR TITLE
Rename edge entry point from devices to fleet-management

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "groups-detail": "/groups/:uuid",
     "device-detail": "/groups/:uuid/:inventoryId",
     "canaries": "/canaries",
-    "devices": "/devices",
-    "devices-detail": "/devices/:inventoryId"
+    "fleet-management": "/fleet-management",
+    "fleet-management-detail": "/fleet-management/:inventoryId"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ const App = (props) => {
   useEffect(() => {
     insights.chrome.init();
     // TODO change this to your appname
-    insights.chrome.identifyApp('devices');
+    insights.chrome.identifyApp('fleet-management');
 
     insights.chrome.on('APP_NAVIGATION', (event) =>
       history.push(`/${event.navId}`)

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -42,10 +42,13 @@ export const Routes = () => {
         {/* <Route exact path={paths['groups-detail']} component={GroupsDetail} /> */}
         {/* <Route path={paths['device-detail']} component={DeviceDetail} /> */}
         {/* <Route path={paths.canaries} component={Canaries} /> */}
-        <Route exact path={paths.devices} component={Devices} />
-        <Route path={paths['devices-detail']} component={DeviceDetail} />
+        <Route exact path={paths['fleet-management']} component={Devices} />
+        <Route
+          path={paths['fleet-management-detail']}
+          component={DeviceDetail}
+        />
         <Route>
-          <Redirect to={paths.devices} />
+          <Redirect to={paths['fleet-management']} />
         </Route>
       </Switch>
     </Suspense>

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -52,8 +52,8 @@ const DeviceDetail = () => {
       <PageHeader>
         <Breadcrumb ouiaId="systems-list">
           <BreadcrumbItem>
-            <Link to={uuid ? `/groups` : '/devices'}>
-              {uuid ? 'Groups' : 'Devices'}
+            <Link to={uuid ? `/groups` : '/fleet-management'}>
+              {uuid ? 'Groups' : 'Fleet management'}
             </Link>
           </BreadcrumbItem>
           {uuid && (

--- a/src/Routes/Devices/Devices.js
+++ b/src/Routes/Devices/Devices.js
@@ -65,7 +65,7 @@ const Devices = () => {
   return (
     <Fragment>
       <PageHeader className="pf-m-light">
-        <PageHeaderTitle title="Available devices" />
+        <PageHeaderTitle title="Fleet management" />
       </PageHeader>
       <Main className="edge-devices">
         <InventoryTable


### PR DESCRIPTION
## Rename devices to fleet management

Since we need some entry point and devices page should not be just another inventory view let's change `devices` route to `fleet-management`.

Merge after: https://github.com/RedHatInsights/cloud-services-config/pull/589