### PR TITLE
Refactor: use image id in the open state instead of map's index

### DIFF
--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -80,11 +80,13 @@ const Images = () => {
             </EmptyState>
           ) : (
             <Table
-              onExpand={(_e, rowIndex) => {
+              aria-label="Manage Images table"
+              onExpand={(_e, _rowIndex, _colIndex, isExpanded, rowData) => {
+                const imageId = rowData.id;
                 setOpened(
-                  opened.includes(rowIndex)
-                    ? opened.filter((item) => item !== rowIndex)
-                    : [...opened, rowIndex]
+                  isExpanded
+                    ? opened.filter((item) => item !== imageId)
+                    : [...opened, imageId]
                 );
               }}
               ariaLabel="Images table"
@@ -96,10 +98,11 @@ const Images = () => {
                   // if there are no packages - disable the option to expand row.
                   const isOpen =
                     packagesNumber > 0
-                      ? opened.some((oneOpen) => oneOpen === 2 * index)
+                      ? opened.some((oneOpen) => oneOpen === item.id)
                       : undefined;
                   return [
                     {
+                      id: item.id,
                       isOpen,
                       cells: [
                         {


### PR DESCRIPTION
So what's happening here?
We were using map function's `index` argument to determined whether a specific row is opened or not.
In addition, in `onExpand` we had the `rowIndex` argument that contains the row number to know whether to hide or display it.

However, it makes the code less readable and more complicate to maintain:
1) Because we are `injecting` the expanded row in the map function the number of rows and therefore their indexes are not the same as in the array that we are mapping.
2) We are using two different methods to filter/check if the expanded row should be displayed or not. In the `map` function we use `2 * index` while in `onExpand` we use `rowIndex`. If we change one of them than it will be hard to notice that the other part needs to be changed as well.

How we fixed it? Using the `id` in the image data. This data is both available in `onExpand` and `map` functions and we use `id` to filter/determine expanded rows. This is far more readable code than what we had before.