### PR TITLE
Fix serving the UI with webpack proxy on BETA

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -12,6 +12,7 @@ const { config: webpackConfig, plugins } = config({
     proxyVerbose: true,
     appUrl: process.env.BETA ? '/beta/edge' : '/edge',
   }),
+  ...(process.env.BETA ? { deployment: 'beta/apps' } : {}),
 });
 
 plugins.push(


### PR DESCRIPTION
This commit adds a small config change in `dev.webpack.config.js`:

**Before** when running `BETA=true npm run start:proxy` and browsing `https://ci.foo.redhat.com:1337/beta/edge` your local changes wouldn't appear in the running UI.

Adding `{ deployment: 'beta/apps' }` to the config object fixes this and now anyone can run their dev environment w/o `insights-proxy`.
:raised_hands: hooray!