### PR TITLE
Integrate edge API in managed images

### DIFF
--- a/src/Routes/ImageManagerDetail/DetailsHeader.js
+++ b/src/Routes/ImageManagerDetail/DetailsHeader.js
@@ -21,7 +21,7 @@ const DetailsHead = () => {
     shallowEqual
   );
 
-  const status = !isLoading && !hasError ? data.status : null;
+  const status = !isLoading && !hasError ? data.Status : null;
 
   return (
     <TextContent>

--- a/src/Routes/ImageManagerDetail/ImageDetail.js
+++ b/src/Routes/ImageManagerDetail/ImageDetail.js
@@ -12,7 +12,7 @@ import { routes as paths } from '../../../package.json';
 import { useDispatch } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { loadImageStatus } from '../../store/actions';
-import { imageStatusReducer, imagesReducer } from '../../store/reducers';
+import { imageStatusReducer } from '../../store/reducers';
 import DetailsHead from './DetailsHeader';
 
 const ImageDetail = () => {
@@ -20,10 +20,7 @@ const ImageDetail = () => {
   const { getRegistry } = useContext(RegistryContext);
   const dispatch = useDispatch();
   useEffect(() => {
-    const registered = getRegistry().register({
-      imageStatusReducer,
-      imagesReducer,
-    });
+    const registered = getRegistry().register({ imageStatusReducer });
     loadImageStatus(dispatch, imageId);
     return () => registered();
   }, [dispatch]);

--- a/src/Routes/ImageManagerDetail/constants.js
+++ b/src/Routes/ImageManagerDetail/constants.js
@@ -5,32 +5,26 @@ import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-
 import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 
 export const composeStatus = [
-  'success',
-  'failure',
-  'pending',
-  'building',
-  'uploading',
-  'registering',
+  'CREATED',
+  'BUILDING',
+  'ERROR',
+  'SUCCESS',
 ];
 
 export const statusIcons = {
   unknown: <QuestionCircleIcon />,
-  success: <CheckCircleIcon />,
-  failure: <TimesCircleIcon />,
-  pending: <PendingIcon />,
-  building: <PendingIcon />,
-  uploading: <PendingIcon />,
-  registering: <PendingIcon />,
+  CREATED: <CheckCircleIcon />,
+  BUILDING: <PendingIcon />,
+  ERROR: <TimesCircleIcon />,
+  SUCCESS: <CheckCircleIcon />,
 };
 
 export const statusColors = {
   unknown: 'grey',
-  success: 'green',
-  failure: 'red',
-  pending: 'cyan',
-  building: 'cyan',
-  uploading: 'cyan',
-  registering: 'cyan',
+  CREATED: 'green',
+  BUILDING: 'cyan',
+  ERROR: 'red',
+  SUCCESS: 'green',
 };
 
 export const releaseMapper = {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -152,7 +152,7 @@ export const fetchActiveImages = ({ limit = 100, offset = 0 } = {}) => {
 };
 
 export const fetchImageStatus = ({ id }) => {
-  return instance.get(`/api/image-builder/v1/composes/${id}`);
+  return instance.get(`${EDGE_API}/images/${id}/status`);
 };
 
 export const fetchDeviceSummary = async () => {
@@ -277,4 +277,8 @@ export const createImage = ({
     },
   };
   return instance.post(`${EDGE_API}/images`, payload);
+};
+
+export const fetchEdgeImages = ({ limit = 100, offset = 0 } = {}) => {
+  return instance.get(`${EDGE_API}/images?limit=${limit}&offset=${offset}`);
 };

--- a/src/store/action-types.js
+++ b/src/store/action-types.js
@@ -3,6 +3,7 @@ import flatMap from 'lodash/flatMap';
 
 export const LOAD_DEVICE_SUMMARY = 'LOAD_DEVICE_SUMMARY';
 export const LOAD_ACTIVE_IMAGES = 'LOAD_ACTIVE_IMAGES';
+export const LOAD_EDGE_IMAGES = 'LOAD_EDGE_IMAGES';
 export const LOAD_GROUPS = 'LOAD_GROUPS';
 export const LOAD_GROUP_DETAIL = 'LOAD_GROUP_DETAIL';
 export const LOAD_TRESHOLD = 'LOAD_TRESHOLD';
@@ -15,6 +16,7 @@ export const CREATE_NEW_IMAGE_RESET = `${CREATE_NEW_IMAGE}_RESET`;
 
 const asyncActions = flatMap(
   [
+    LOAD_EDGE_IMAGES,
     LOAD_ACTIVE_IMAGES,
     LOAD_GROUPS,
     LOAD_GROUP_DETAIL,

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -9,6 +9,7 @@ import {
   PRE_SELECT_ENTITY,
   CLEAN_ENTITIES,
   LOAD_ACTIVE_IMAGES,
+  LOAD_EDGE_IMAGES,
   LOAD_DEVICE_SUMMARY,
   LOAD_IMAGE_STATUS,
   CREATE_NEW_IMAGE,
@@ -23,6 +24,7 @@ import {
   fetchActiveImages,
   fetchDeviceSummary,
   fetchImageStatus,
+  fetchEdgeImages,
   createImage,
 } from '../api';
 
@@ -117,7 +119,7 @@ export const loadDeviceSummary = (dispatch) => {
 export const loadImageStatus = (dispatch, imageId) => {
   dispatch({
     type: LOAD_IMAGE_STATUS,
-    payload: fetchImageStatus(imageId),
+    payload: fetchImageStatus({ id: imageId }),
   }).catch(() => null);
 };
 
@@ -128,4 +130,11 @@ export const createNewImage = (dispatch, payload, callback) => {
   })
     .then(() => callback())
     .catch(() => null);
+};
+
+export const loadEdgeImages = (dispatch, query) => {
+  dispatch({
+    type: LOAD_EDGE_IMAGES,
+    payload: fetchEdgeImages(query),
+  }).catch(() => null);
 };

--- a/src/store/edgeImages.js
+++ b/src/store/edgeImages.js
@@ -1,0 +1,35 @@
+import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
+import { LOAD_EDGE_IMAGES } from './action-types';
+
+const initialState = {};
+
+const loadEdgeImagesPending = () => ({
+  isLoading: true,
+  hasError: false,
+  data: null,
+});
+
+const loadEdgeImagesFulfilled = (state, { payload }) => {
+  return {
+    ...state,
+    isLoading: false,
+    hasError: false,
+    data: payload,
+  };
+};
+
+const loadEdgeImagesRejected = (state, { payload }) => ({
+  ...state,
+  isLoading: false,
+  hasError: true,
+  data: payload,
+});
+
+export default applyReducerHash(
+  {
+    [`${LOAD_EDGE_IMAGES}_PENDING`]: loadEdgeImagesPending,
+    [`${LOAD_EDGE_IMAGES}_FULFILLED`]: loadEdgeImagesFulfilled,
+    [`${LOAD_EDGE_IMAGES}_REJECTED`]: loadEdgeImagesRejected,
+  },
+  initialState
+);

--- a/src/store/edgeImages.test.js
+++ b/src/store/edgeImages.test.js
@@ -1,0 +1,45 @@
+import reducer from './edgeImages';
+import { LOAD_EDGE_IMAGES } from './action-types';
+
+describe('reducer', () => {
+  it('should calculate pending', () => {
+    expect(
+      reducer(undefined, {
+        type: `${LOAD_EDGE_IMAGES}_PENDING`,
+      })
+    ).toMatchObject({ isLoading: true, hasError: false, data: null });
+  });
+
+  it('should calculate fulfilled on success', () => {
+    const payload = {
+      meta: {
+        count: 0,
+      },
+      data: [],
+    };
+    expect(
+      reducer(undefined, {
+        type: `${LOAD_EDGE_IMAGES}_FULFILLED`,
+        payload,
+      })
+    ).toMatchObject({
+      isLoading: false,
+      hasError: false,
+      data: payload,
+    });
+  });
+
+  it('should calculate fulfilled on error', () => {
+    const err = new Error('Network issue');
+    expect(
+      reducer(undefined, {
+        type: `${LOAD_EDGE_IMAGES}_REJECTED`,
+        payload: err,
+      })
+    ).toMatchObject({
+      isLoading: false,
+      hasError: true,
+      data: err,
+    });
+  });
+});

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -1,5 +1,6 @@
 export { default as deviceSummaryReducer } from './deviceSummary';
 export { default as imagesReducer } from './images';
+export { default as edgeImagesReducer } from './edgeImages';
 export { default as imageStatusReducer } from './imageStatus';
 export { default as groupsReducer } from './groups';
 export { default as thresholdReducer } from './threshold';


### PR DESCRIPTION
This patch makes the image data come from Edge API service.
I had to do small changes to not break the current state:
1) Create a different Redux reducer and actions to not break the available images tile.
2) Add `fetchEdgeImages` to retrieve the data from Edge API
3) Rename image status mapper to match Edge API response
4) Add empty state when no image was found