### PR TITLE
Fix filter key is invalid error in fleet-management

### DIFF
--- a/src/Routes/Devices/Devices.js
+++ b/src/Routes/Devices/Devices.js
@@ -109,13 +109,13 @@ const Devices = () => {
                   ...config.filter?.system_profile,
                   host_type: 'edge',
                 },
-                fields: {
-                  ...config?.fields,
-                  system_profile: [
-                    ...(config?.fields?.system_profile || []),
-                    'host_type',
-                  ],
-                },
+              },
+              fields: {
+                ...config?.fields,
+                system_profile: [
+                  ...(config?.fields?.system_profile || []),
+                  'host_type',
+                ],
               },
             });
             return data;

--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -233,36 +233,40 @@ const Images = () => {
                           ];
                         })
                       )
-                    : [{
-                      heightAuto: true,
-                      cells: [
+                    : [
                         {
-                          props: { colSpan: 8 },
-                          title: (
-            <Bullseye>
-              <EmptyState variant="small">
-                <EmptyStateIcon icon={PlusCircleIcon} />
-                <Title headingLevel="h2" size="lg">
-                  No images found
-                </Title>
-                  <Button
-                      onClick={() => {
-                        history.push({
-                          pathname: history.location.pathname,
-                          search: new URLSearchParams({
-                            create_image: true,
-                          }).toString(),
-                        });
-                        setIsOpen(true);
-                      }}
-                      isDisabled={isLoading !== false}
-                  >Create new images</Button>
-              </EmptyState>
-            </Bullseye>
-                          )
-                        }
+                          heightAuto: true,
+                          cells: [
+                            {
+                              props: { colSpan: 8 },
+                              title: (
+                                <Bullseye>
+                                  <EmptyState variant="small">
+                                    <EmptyStateIcon icon={PlusCircleIcon} />
+                                    <Title headingLevel="h2" size="lg">
+                                      No images found
+                                    </Title>
+                                    <Button
+                                      onClick={() => {
+                                        history.push({
+                                          pathname: history.location.pathname,
+                                          search: new URLSearchParams({
+                                            create_image: true,
+                                          }).toString(),
+                                        });
+                                        setIsOpen(true);
+                                      }}
+                                      isDisabled={isLoading !== false}
+                                    >
+                                      Create new images
+                                    </Button>
+                                  </EmptyState>
+                                </Bullseye>
+                              ),
+                            },
+                          ],
+                        },
                       ]
-                    }]
                 }
               >
                 <TableHeader />

--- a/src/Routes/ImageManagerDetail/constants.js
+++ b/src/Routes/ImageManagerDetail/constants.js
@@ -4,12 +4,7 @@ import PendingIcon from '@patternfly/react-icons/dist/js/icons/pending-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 
-export const composeStatus = [
-  'CREATED',
-  'BUILDING',
-  'ERROR',
-  'SUCCESS',
-];
+export const composeStatus = ['CREATED', 'BUILDING', 'ERROR', 'SUCCESS'];
 
 export const statusIcons = {
   unknown: <QuestionCircleIcon />,


### PR DESCRIPTION
@karelhala mind giving it a look.
I lately get a filter key is invalid error notification and not being able to load the inventory table.
I realized that one of the search query we pass is invalid. After few minutes of debugging I think we had a miss configuration
in the config we are passing to "onRefresh": we put "fields" under "filter" while it's supposed to be its sibling.

