### PR TITLE
Update create image wizard

### DIFF
--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ImageCreator from '../../components/ImageCreator';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { registration, review, packages, imageOutput } from './steps';
+import { registration, review, packages, imageSetDetails, imageOutput } from './steps';
 import { Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import ReviewStep from '../../components/form/ReviewStep';
@@ -54,7 +54,7 @@ const CreateImage = ({ navigateBack }) => {
             description: 'Create RHEL for Edge image',
             // order in this array does not reflect order in wizard nav, this order is managed inside
             // of each step by `nextStep` property!
-            fields: [imageOutput, registration, packages, review],
+            fields: [imageSetDetails, imageOutput, registration, packages, review],
           },
         ],
       }}

--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -1,7 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import ImageCreator from '../../components/ImageCreator';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { registration, review, packages, imageSetDetails, imageOutput } from './steps';
+import { 
+  registration, 
+  review, 
+  packages, 
+  imageSetDetails, 
+  imageOutput 
+} from './steps';
 import { Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import ReviewStep from '../../components/form/ReviewStep';
@@ -54,7 +60,13 @@ const CreateImage = ({ navigateBack }) => {
             description: 'Create RHEL for Edge image',
             // order in this array does not reflect order in wizard nav, this order is managed inside
             // of each step by `nextStep` property!
-            fields: [imageSetDetails, imageOutput, registration, packages, review],
+            fields: [
+              imageSetDetails, 
+              imageOutput, 
+              registration, 
+              packages, 
+              review
+            ],
           },
         ],
       }}

--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import ImageCreator from '../../components/ImageCreator';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { 
-  registration, 
-  review, 
-  packages, 
-  imageSetDetails, 
-  imageOutput 
+import {
+  registration,
+  review,
+  packages,
+  imageSetDetails,
+  imageOutput,
 } from './steps';
 import { Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
@@ -61,11 +61,11 @@ const CreateImage = ({ navigateBack }) => {
             // order in this array does not reflect order in wizard nav, this order is managed inside
             // of each step by `nextStep` property!
             fields: [
-              imageSetDetails, 
-              imageOutput, 
-              registration, 
-              packages, 
-              review
+              imageSetDetails,
+              imageOutput,
+              registration,
+              packages,
+              review,
             ],
           },
         ],

--- a/src/Routes/ImageManager/steps/imageOutput.js
+++ b/src/Routes/ImageManager/steps/imageOutput.js
@@ -33,17 +33,17 @@ export default {
       isDisabled: true,
     },
     {
-      component: componentTypes.CHECKBOX,
+      component: 'image-output-checkbox',
       name: 'imageType',
-      label: 'Output Type',
       options: Object.entries(imageTypeMapper).map(
         ([imageType, imageTypeLabel]) => ({
           value: imageType,
           label: imageTypeLabel,
         })
       ),
+      initialValue: ['rhel-edge-installer'],
+      clearedValue: [],
       validate: [{ type: validatorTypes.REQUIRED }],
-      isRequired: true,
     },
   ],
 };

--- a/src/Routes/ImageManager/steps/imageOutput.js
+++ b/src/Routes/ImageManager/steps/imageOutput.js
@@ -33,7 +33,7 @@ export default {
       isDisabled: true,
     },
     {
-      component: componentTypes.SELECT,
+      component: componentTypes.CHECKBOX,
       name: 'imageType',
       label: 'Output Type',
       options: Object.entries(imageTypeMapper).map(
@@ -42,10 +42,8 @@ export default {
           label: imageTypeLabel,
         })
       ),
-      initialValue: 'rhel-edge-installer',
       validate: [{ type: validatorTypes.REQUIRED }],
       isRequired: true,
-      isDisabled: true,
     },
   ],
 };

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -23,7 +23,13 @@ export default {
       name: 'image-name',
       label: 'Image Name',
       placeholder: 'Image Name',
-      validate: [{ type: validatorTypes.REQUIRED }],
+      validate: [
+        { type: validatorTypes.REQUIRED },
+        {
+          type: validatorTypes.PATTERN,
+          pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
+        },
+      ],
       isRequired: true,
     },
     {

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -12,8 +12,9 @@ export default {
       component: componentTypes.PLAIN_TEXT,
       name: 'description',
       label: (
-        <Text>How would you like to identify this image later?
-          What will it be used for?
+        <Text>
+          How would you like to identify this image later? What will it be used
+          for?
         </Text>
       ),
     },

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -12,8 +12,7 @@ export default {
       component: componentTypes.PLAIN_TEXT,
       name: 'description',
       label: (
-        <Text>
-          How would you like to identify this image later? 
+        <Text>How would you like to identify this image later?
           What will it be used for?
         </Text>
       ),
@@ -31,6 +30,6 @@ export default {
       name: 'description',
       label: 'Description',
       placeholder: 'Add Description',
-    }
+    },
   ],
-}
+};

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import { Text } from '@patternfly/react-core';
+import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
+
+export default {
+  title: 'Image Set Details',
+  name: 'imageSetDetails',
+  nextStep: 'imageOutput',
+  fields: [
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'description',
+      label: (
+        <Text>
+          How would you like to identify this image later? 
+          What will it be used for?
+        </Text>
+      ),
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'image-name',
+      label: 'Image Name',
+      placeholder: 'Image Name',
+      validate: [{ type: validatorTypes.REQUIRED }],
+      isRequired: true,
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'description',
+      label: 'Description',
+      placeholder: 'Add Description',
+    }
+  ],
+}

--- a/src/Routes/ImageManager/steps/index.js
+++ b/src/Routes/ImageManager/steps/index.js
@@ -1,4 +1,5 @@
 export { default as review } from './review';
 export { default as packages } from './packages';
 export { default as imageOutput } from './imageOutput';
+export { default as imageSetDetails } from './imageSetDetails';
 export { default as registration } from './registration';

--- a/src/Routes/ImageManager/steps/registration.js
+++ b/src/Routes/ImageManager/steps/registration.js
@@ -39,8 +39,7 @@ export default {
       component: componentTypes.TEXTAREA,
       name: 'credentials',
       label: 'SSH Key',
-      helperText:
-        'Paste your public SSH key here',
+      helperText: 'Paste your public SSH key here',
       validate: [{ type: validatorTypes.REQUIRED }],
       isRequired: true,
       resizeOrientation: 'vertical',

--- a/src/Routes/ImageManager/steps/registration.js
+++ b/src/Routes/ImageManager/steps/registration.js
@@ -22,6 +22,7 @@ export default {
       component: componentTypes.TEXT_FIELD,
       name: 'username',
       label: 'Username',
+      placeholder: 'Enter username',
       helperText:
         'The user name can only consist of letters from a-z, digits, dots, dashes and underscores.',
       validate: [
@@ -35,11 +36,14 @@ export default {
       isRequired: true,
     },
     {
-      component: 'registration-creds',
+      component: componentTypes.TEXTAREA,
       name: 'credentials',
-      initialValue: [],
-      clearedValue: [],
-      validate: [{ type: 'registrationCredsValidator' }],
+      label: 'SSH Key',
+      helperText:
+        'Paste your public SSH key here',
+      validate: [{ type: validatorTypes.REQUIRED }],
+      isRequired: true,
+      resizeOrientation: 'vertical',
     },
   ],
 };

--- a/src/Routes/ImageManager/steps/registration.js
+++ b/src/Routes/ImageManager/steps/registration.js
@@ -1,48 +1,40 @@
 import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { Text } from '@patternfly/react-core';
+import { TextContent, Text } from '@patternfly/react-core';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 
 export default {
-  title: 'Registration',
+  title: 'Device Registration',
   name: 'registration',
   nextStep: 'packages',
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
       name: 'description',
-      label: (
-        <Text>
-          A user is required to register the device and make it visible on
-          cloud.redhat.com
-        </Text>
-      ),
+      label: <Text>Use this to connect your device to Fleet Management.</Text>,
     },
     {
       component: componentTypes.TEXT_FIELD,
       name: 'username',
-      label: 'Username',
-      placeholder: 'Enter username',
-      helperText:
-        'The user name can only consist of letters from a-z, digits, dots, dashes and underscores.',
-      validate: [
-        { type: validatorTypes.REQUIRED },
-        {
-          type: validatorTypes.PATTERN,
-          pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
-        },
-        { type: validatorTypes.MIN_LENGTH, threshold: 5 },
-      ],
-      isRequired: true,
+      helperText: (
+        <TextContent>
+          <Text>
+            <strong>Username</strong>
+          </Text>
+          <Text>
+            Use the default <strong>root</strong> username to log in and
+            register your device.
+          </Text>
+        </TextContent>
+      ),
+      initialValue: 'root',
+      hidden: true,
     },
     {
-      component: componentTypes.TEXTAREA,
+      component: 'ssh-input-field',
       name: 'credentials',
-      label: 'SSH Key',
-      helperText: 'Paste your public SSH key here',
       validate: [{ type: validatorTypes.REQUIRED }],
       isRequired: true,
-      resizeOrientation: 'vertical',
     },
   ],
 };

--- a/src/components/ImageCreator.js
+++ b/src/components/ImageCreator.js
@@ -8,6 +8,8 @@ import PropTypes from 'prop-types';
 import Review from './form/ReviewStep';
 import Packages from './form/Packages';
 import RegistrationCreds from './form/RegistrationCreds';
+import ImageOutputCheckbox from './form/ImageOutputCheckbox';
+import SSHInputField from './form/SSHInputField';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { registrationCredsValidator } from './form/RegistrationCreds';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
@@ -47,6 +49,12 @@ const CreateImageWizard = ({
         // wizard: WrappedWizard,
         'registration-creds': {
           component: RegistrationCreds,
+        },
+        'image-output-checkbox': {
+          component: ImageOutputCheckbox,
+        },
+        'ssh-input-field': {
+          component: SSHInputField,
         },
         review: Review,
         'package-selector': {

--- a/src/components/ReviewSection.js
+++ b/src/components/ReviewSection.js
@@ -22,7 +22,7 @@ const ReviewSection = ({ title, data, testid }) => {
               {name}
             </TextListItem>
           </GridItem>
-          <GridItem style={{ paddingBottom: '20px' }} span={9} hasGutter>
+          <GridItem className="pf-u-pb-md" span={9} hasGutter>
             <TextListItem component={TextListItemVariants.dd}>
               {value}
             </TextListItem>

--- a/src/components/ReviewSection.js
+++ b/src/components/ReviewSection.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { 
+  Text, 
+  Grid,
+  GridItem,
+  TextListItem,
+  TextVariants,
+  TextListItemVariants,
+} from '@patternfly/react-core';
+
+const ReviewSection = ({ title, data, testid }) => {
+  return (
+    <Grid
+      data-testid={testid}
+      hasGutter
+    >
+      <GridItem span={12} hasGutter>
+        <Text component={TextVariants.h1}>{title}</Text> 
+      </GridItem>
+      {data.map(({ name, value }) => 
+        <>
+          <GridItem span={3} hasGutter>
+            <TextListItem component={TextListItemVariants.dt}>{name}</TextListItem>
+          </GridItem>
+          <GridItem style={{ paddingBottom: '20px' }} span={9} hasGutter>
+            <TextListItem component={TextListItemVariants.dd}>{value}</TextListItem>
+          </GridItem>
+        </>
+      )}
+    </Grid>
+  )
+}
+
+export default ReviewSection;

--- a/src/components/ReviewSection.js
+++ b/src/components/ReviewSection.js
@@ -5,8 +5,9 @@ import {
   GridItem,
   TextListItem,
   TextVariants,
-  TextListItemVariants
+  TextListItemVariants,
 } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
 
 const ReviewSection = ({ title, data, testid }) => {
   return (
@@ -33,12 +34,14 @@ const ReviewSection = ({ title, data, testid }) => {
 };
 
 ReviewSection.propTypes = {
-  title: propTypes.string,
-  data: propTypes.arrayOf(propTypes.shape({
-    name: propTypes.string,
-    value: propTypes.string,
-  })),
-  testid: propTypes.string
+  title: PropTypes.string,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      value: PropTypes.string,
+    })
+  ),
+  testid: PropTypes.string,
 };
 
 export default ReviewSection;

--- a/src/components/ReviewSection.js
+++ b/src/components/ReviewSection.js
@@ -1,34 +1,44 @@
 import React from 'react';
-import { 
-  Text, 
+import {
+  Text,
   Grid,
   GridItem,
   TextListItem,
   TextVariants,
-  TextListItemVariants,
+  TextListItemVariants
 } from '@patternfly/react-core';
 
 const ReviewSection = ({ title, data, testid }) => {
   return (
-    <Grid
-      data-testid={testid}
-      hasGutter
-    >
+    <Grid data-testid={testid} hasGutter>
       <GridItem span={12} hasGutter>
-        <Text component={TextVariants.h1}>{title}</Text> 
+        <Text component={TextVariants.h1}>{title}</Text>
       </GridItem>
-      {data.map(({ name, value }) => 
+      {data.map(({ name, value }) => (
         <>
           <GridItem span={3} hasGutter>
-            <TextListItem component={TextListItemVariants.dt}>{name}</TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              {name}
+            </TextListItem>
           </GridItem>
           <GridItem style={{ paddingBottom: '20px' }} span={9} hasGutter>
-            <TextListItem component={TextListItemVariants.dd}>{value}</TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {value}
+            </TextListItem>
           </GridItem>
         </>
-      )}
+      ))}
     </Grid>
-  )
-}
+  );
+};
+
+ReviewSection.propTypes = {
+  title: propTypes.string,
+  data: propTypes.arrayOf(propTypes.shape({
+    name: propTypes.string,
+    value: propTypes.string,
+  })),
+  testid: propTypes.string
+};
 
 export default ReviewSection;

--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -1,0 +1,50 @@
+import React, { useCallback } from 'react';
+import { FormGroup, Checkbox } from '@patternfly/react-core';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import PropTypes from 'prop-types';
+
+const ImageOutputCheckbox = (props) => {
+  const { input } = useFieldApi(props);
+  const toggleCheckbox = useCallback(
+    (checked, event) => {
+      input.onChange(
+        checked
+          ? [...input.value, event.currentTarget.id]
+          : input.value.filter((item) => item !== event.currentTarget.id)
+      );
+    },
+    [input.onChange]
+  );
+
+  return (
+    <FormGroup
+      label="Output Type"
+      isHelperTextBeforeField
+      hasNoPaddingTop
+      isRequired
+      isStack
+    >
+      {props.options.map(({ value, label }, index) => (
+        <Checkbox
+          key={index}
+          label={label}
+          id={value}
+          isChecked={input.value.includes(value)}
+          onChange={toggleCheckbox}
+        />
+      ))}
+    </FormGroup>
+  );
+};
+
+ImageOutputCheckbox.propTypes = {
+  input: PropTypes.array,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    })
+  ),
+};
+
+export default ImageOutputCheckbox;

--- a/src/components/form/ReviewStep.js
+++ b/src/components/form/ReviewStep.js
@@ -1,10 +1,10 @@
 import React, { Fragment, useContext, useEffect } from 'react';
 import { TextContent, Text } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
-import { 
+import {
   imageTypeMapper,
-  releaseMapper
-} from  '../../Routes/ImageManagerDetail/constants';
+  releaseMapper,
+} from '../../Routes/ImageManagerDetail/constants';
 import { shallowEqual, useSelector } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { createImageReducer } from '../../store/reducers';
@@ -45,10 +45,10 @@ const ReviewStep = () => {
 
   const output = [
     { name: 'Release', value: releaseMapper[getState().values.release] },
-    { name: 'Type',
+    {
+      name: 'Type',
       value: getState()
-      .values.imageType.map(type =>
-        `${imageTypeMapper[type]}`)
+        .values.imageType.map((type) => `${imageTypeMapper[type]}`)
         .join(', '),
     },
   ];
@@ -61,15 +61,16 @@ const ReviewStep = () => {
   const packages = [
     {
       name: 'Added Packages',
-      value: getState().values['selected-packages'] === undefined
-      ? '0'
-      : getState().values['selected-packages'].length
+      value:
+        getState().values['selected-packages'] === undefined
+          ? '0'
+          : getState().values['selected-packages'].length,
     },
   ];
 
   return (
     <Fragment>
-      {hasError &&(
+      {hasError && (
         <Alert
           variant="danger"
           title="Failed sending the request: Edge API is not available"
@@ -84,7 +85,7 @@ const ReviewStep = () => {
           title={'Details'}
           data={details}
           testid={'review-image-details'}
-        /> 
+        />
         <ReviewSection
           title={'Output'}
           data={output}

--- a/src/components/form/ReviewStep.js
+++ b/src/components/form/ReviewStep.js
@@ -13,7 +13,6 @@ import ReviewSection from '../ReviewSection';
 
 const ReviewStep = () => {
   const { getState } = useFormApi();
-  console.log(getState().values);
   const { getRegistry } = useContext(RegistryContext);
   const { isLoading, hasError } = useSelector(
     ({ createImageReducer }) => ({

--- a/src/components/form/ReviewStep.js
+++ b/src/components/form/ReviewStep.js
@@ -2,20 +2,18 @@ import React, { Fragment, useContext, useEffect } from 'react';
 import {
   TextContent,
   Text,
-  TextVariants,
-  TextList,
-  TextListItem,
-  TextListVariants,
-  TextListItemVariants,
 } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import { imageTypeMapper, releaseMapper } from  '../../Routes/ImageManagerDetail/constants';
 import { shallowEqual, useSelector } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { createImageReducer } from '../../store/reducers';
 import { Bullseye, Spinner, Alert } from '@patternfly/react-core';
+import ReviewSection from '../ReviewSection';
 
 const ReviewStep = () => {
   const { getState } = useFormApi();
+  console.log(getState().values);
   const { getRegistry } = useContext(RegistryContext);
   const { isLoading, hasError } = useSelector(
     ({ createImageReducer }) => ({
@@ -41,6 +39,33 @@ const ReviewStep = () => {
     );
   }
 
+  const details = [
+    { name: 'Name', value: getState().values['image-name'] }, 
+    { name: 'Description', value: getState().values.description }
+  ];
+
+  const output = [
+    { name: 'Release', value: releaseMapper[getState().values.release] }, 
+    { name: 'Type', 
+      value: getState().values.imageType.map(type =>
+        `${imageTypeMapper[type]}`)
+        .join(', ')
+    }
+  ];
+
+  const registration = [
+    { name: 'Username', value: getState().values['username'] }, 
+    { name: 'ssh-key', value: getState().values.credentials }
+  ];
+
+  const packages = [
+    { name: 'Added Packages', 
+      value: getState().values['selected-packages'] === undefined
+              ? 0
+              : getState().values['selected-packages'].length
+    }
+  ];
+
   return (
     <Fragment>
       {hasError && (
@@ -54,65 +79,27 @@ const ReviewStep = () => {
           Review the information and click the Create button to create your
           image using the following criteria.
         </Text>
-        <Text component={TextVariants.h1}>Image output</Text>
-        <TextList
-          component={TextListVariants.dl}
-          data-testid="review-image-output"
-        >
-          <TextListItem component={TextListItemVariants.dt}>
-            Release
-          </TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>
-            Red Hat Enterprise Linux (RHEL) 8.3
-          </TextListItem>
-        </TextList>
-        <Text component={TextVariants.h1}>Registration</Text>
-        <TextList
-          component={TextListVariants.dl}
-          data-testid="review-image-registration"
-        >
-          <TextListItem component={TextListItemVariants.dt}>
-            Username
-          </TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>
-            {getState().values['username']}
-          </TextListItem>
-          {getState().values.credentials.includes('password') ? (
-            <>
-              <TextListItem component={TextListItemVariants.dt}>
-                Password
-              </TextListItem>
-              <TextListItem component={TextListItemVariants.dd} type="password">
-                {'*'.repeat(getState().values.password.length)}
-              </TextListItem>
-            </>
-          ) : null}
-          {getState().values.credentials.includes('sshKey') ? (
-            <>
-              <TextListItem component={TextListItemVariants.dt}>
-                SSH Key
-              </TextListItem>
-              <TextListItem component={TextListItemVariants.dd} type="password">
-                {getState().values.sshKey}
-              </TextListItem>
-            </>
-          ) : null}
-        </TextList>
-        <Text component={TextVariants.h1}>Packages</Text>
-        <TextList
-          component={TextListVariants.dl}
-          data-testid="review-image-packages"
-        >
-          <TextListItem component={TextListItemVariants.dt}>
-            Added Packages
-          </TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>
-            {getState().values['selected-packages'] === undefined
-              ? 0
-              : getState().values['selected-packages'].length}
-          </TextListItem>
-        </TextList>
-      </TextContent>
+        <ReviewSection 
+          title={'Details'}
+          data={details}
+          testid={'review-image-details'}
+        /> 
+        <ReviewSection 
+          title={'Output'}
+          data={output}
+          testid={'review-image-output'}
+        />
+        <ReviewSection 
+          title={'Registration'}
+          data={registration}
+          testid={'review-image-registration'}
+        />
+        <ReviewSection 
+          title={'Packages'}
+          data={packages}
+          testid={'review-image-packages'}
+        />
+        </TextContent>
     </Fragment>
   );
 };

--- a/src/components/form/ReviewStep.js
+++ b/src/components/form/ReviewStep.js
@@ -1,10 +1,10 @@
 import React, { Fragment, useContext, useEffect } from 'react';
-import {
-  TextContent,
-  Text,
-} from '@patternfly/react-core';
+import { TextContent, Text } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
-import { imageTypeMapper, releaseMapper } from  '../../Routes/ImageManagerDetail/constants';
+import { 
+  imageTypeMapper,
+  releaseMapper
+} from  '../../Routes/ImageManagerDetail/constants';
 import { shallowEqual, useSelector } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { createImageReducer } from '../../store/reducers';
@@ -39,35 +39,37 @@ const ReviewStep = () => {
   }
 
   const details = [
-    { name: 'Name', value: getState().values['image-name'] }, 
-    { name: 'Description', value: getState().values.description }
+    { name: 'Name', value: getState().values['image-name'] },
+    { name: 'Description', value: getState().values.description },
   ];
 
   const output = [
-    { name: 'Release', value: releaseMapper[getState().values.release] }, 
-    { name: 'Type', 
-      value: getState().values.imageType.map(type =>
+    { name: 'Release', value: releaseMapper[getState().values.release] },
+    { name: 'Type',
+      value: getState()
+      .values.imageType.map(type =>
         `${imageTypeMapper[type]}`)
-        .join(', ')
-    }
+        .join(', '),
+    },
   ];
 
   const registration = [
-    { name: 'Username', value: getState().values['username'] }, 
-    { name: 'ssh-key', value: getState().values.credentials }
+    { name: 'Username', value: getState().values['username'] },
+    { name: 'ssh-key', value: getState().values.credentials },
   ];
 
   const packages = [
-    { name: 'Added Packages', 
+    {
+      name: 'Added Packages',
       value: getState().values['selected-packages'] === undefined
-              ? 0
-              : getState().values['selected-packages'].length
-    }
+      ? '0'
+      : getState().values['selected-packages'].length
+    },
   ];
 
   return (
     <Fragment>
-      {hasError && (
+      {hasError &&(
         <Alert
           variant="danger"
           title="Failed sending the request: Edge API is not available"
@@ -78,27 +80,27 @@ const ReviewStep = () => {
           Review the information and click the Create button to create your
           image using the following criteria.
         </Text>
-        <ReviewSection 
+        <ReviewSection
           title={'Details'}
           data={details}
           testid={'review-image-details'}
         /> 
-        <ReviewSection 
+        <ReviewSection
           title={'Output'}
           data={output}
           testid={'review-image-output'}
         />
-        <ReviewSection 
+        <ReviewSection
           title={'Registration'}
           data={registration}
           testid={'review-image-registration'}
         />
-        <ReviewSection 
+        <ReviewSection
           title={'Packages'}
           data={packages}
           testid={'review-image-packages'}
         />
-        </TextContent>
+      </TextContent>
     </Fragment>
   );
 };

--- a/src/components/form/SSHInputField.js
+++ b/src/components/form/SSHInputField.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  FormGroup,
+  TextInput,
+  TextContent,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const SSHInputField = () => {
+  const { input: sshKeyInput } = useFieldApi({ name: 'credentials' });
+  return (
+    <FormGroup
+      label="Output Type"
+      isHelperTextBeforeField
+      hasNoPaddingTop
+      isRequired
+      isStack
+    >
+      <TextInput
+        id="credentials"
+        placeholder="Enter SSH key"
+        {...sshKeyInput}
+      />
+      <TextContent>
+        <Text component={TextVariants.small}>
+          Paste your public SSH key file here.
+        </Text>
+      </TextContent>
+      <Text component={TextVariants.small}>
+        <Text
+          target="_blank"
+          href="https://en.wikipedia.org/wiki/Secure_Shell_Protocol"
+          isVisitedLink
+          component={TextVariants.a}
+        >
+          Learn more about SSH keys
+          <ExternalLinkAltIcon className="pf-u-ml-sm" />
+        </Text>
+      </Text>
+    </FormGroup>
+  );
+};
+
+export default SSHInputField;


### PR DESCRIPTION
Several commits for each task done. 
- Created new image details step for wizard
- Changed image output to checkboxes
- Removed password from registration
- Updated review step page with newly aligned content and added new component

Notes
- On removing the registration step I changed from calling the registrationCreds to using DDF component types. Can add more validation to ssh with ddf, as well as any others.
- Attempted to add default checked for output image. Need some advice on how to do that. (wouldnt accept isChecked / checked)
- I switched from textlist to grid due to having issues with aligning the items and the need to keep data-testid attr (hopefully the data being nested isnt too bad)