### PR TITLE
Sort by created_at in descending order to see new images first

### DIFF
--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -82,7 +82,7 @@ const Images = () => {
   const [page, setPage] = useState(1);
   const [isOpen, setIsOpen] = useState(false);
   const [opened, setOpened] = useState([]);
-  const [sortBy, setSortBy] = useState({ index: 4, direction: 'asc' });
+  const [sortBy, setSortBy] = useState({ index: 4, direction: 'desc' });
   const dispatch = useDispatch();
   const { getRegistry } = useContext(RegistryContext);
   const { isLoading, hasError, data } = useSelector(

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -286,7 +286,7 @@ export const createImage = ({
 export const fetchEdgeImages = ({
   limit = 100,
   offset = 0,
-  sortColunm = 'created_at',
+  sortColunm = '-created_at',
 } = {}) => {
   return instance.get(
     `${EDGE_API}/images?limit=${limit}&offset=${offset}&sort_by=${sortColunm}`


### PR DESCRIPTION
This is a small fix. By default we sort the images by "created_at" in "asc" order. Which puts the oldest images at the top of the list while we want the other way around.

To fix it, I changed the default values in the API function and in the hook state.