### PR TITLE
Fix small problems with wizard

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -267,9 +267,13 @@ export const createImage = ({
   description,
   release,
   architecture,
-  imageType,
+  imageType: imageTypes,
   'selected-packages': packages,
 }) => {
+  let imageType = imageTypes[0];
+  if (imageTypes.length > 1) {
+    imageType = 'rhel-edge-installer';
+  }
   const payload = {
     name,
     description,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -270,7 +270,7 @@ export const createImage = ({
   imageType: imageTypes,
   'selected-packages': packages,
 }) => {
-  let imageType = imageTypes[0];
+  let [ imageType ] = imageTypes || [];
   if (imageTypes.length > 1) {
     imageType = 'rhel-edge-installer';
   }

--- a/src/components/form/ReviewStep.js
+++ b/src/components/form/ReviewStep.js
@@ -40,7 +40,7 @@ const ReviewStep = () => {
 
   const details = [
     { name: 'Name', value: getState().values.name },
-    { name: 'Version', value: '2' },
+    { name: 'Version', value: '1' },
     { name: 'Description', value: getState().values.description },
   ];
 


### PR DESCRIPTION
This patch contains small fixes to changes that were made in the create image wizard:
1) Version is 1 by default
2) Right now the API supports imageType as a string. And we are passing an array. Because of that if imageType is both commit and installer set it to installer as when setting installer we will have the tar file automatically. If imageType is set to only one of the option then set it.