### PR TITLE
changed sortColumn to sort_by for api query

### DIFF
--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -259,13 +259,13 @@ const Images = () => {
       loadEdgeImages(dispatch, {
         limit: perPage,
         offset: (page - 1) * perPage,
-        sortColunm: columns[sortBy.index].type,
+        sort_by: columns[sortBy.index].type,
       });
     } else {
       loadEdgeImages(dispatch, {
         limit: perPage,
         offset: (page - 1) * perPage,
-        sortColunm: `-${columns[sortBy.index].type}`,
+        sort_by: `-${columns[sortBy.index].type}`,
       });
     }
   }, [page, perPage, sortBy]);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -291,7 +291,7 @@ export const fetchEdgeImages = (
   q = {
     limit: 100,
     offset: 0,
-    sortColunm: '-created_at',
+    sort_by: '-created_at',
   }
 ) => {
   const query = Object.keys(q).reduce((acc, curr) => {


### PR DESCRIPTION
Changed sortColumn to sort_by to fix the API query for sorting columns in the manage images table.