### PR TITLE
Wizard package fix

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -281,7 +281,7 @@ export const createImage = ({
     imageType,
     commit: {
       arch: architecture,
-      packages: packages.map((item) => ({ name: item })),
+      packages
     },
   };
   return instance.post(`${EDGE_API}/images`, payload);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -281,7 +281,7 @@ export const createImage = ({
     imageType,
     commit: {
       arch: architecture,
-      packages
+      packages,
     },
   };
   return instance.post(`${EDGE_API}/images`, payload);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -281,7 +281,7 @@ export const createImage = ({
     imageType,
     commit: {
       arch: architecture,
-      packages,
+      packages: packages.map((item) => ({ name: item.name })),
     },
   };
   return instance.post(`${EDGE_API}/images`, payload);


### PR DESCRIPTION
create image from wizard would receive error from backend api when adding package. Backend was expecting a different format.
previous format: `[ name: { name:'vim' } ]`  expected: `[ { name: 'vim' } ]` changed to expected