### PR TITLE
Add ed25519 pattern to valid ssh key type regex pattern and disable clickable on device summary page

### DIFF
--- a/src/Routes/ImageManager/steps/registration.js
+++ b/src/Routes/ImageManager/steps/registration.js
@@ -35,7 +35,7 @@ export default {
         { type: validatorTypes.REQUIRED },
         {
           type: validatorTypes.PATTERN,
-          pattern: /^(ssh-(rsa|dss)|ecdsa-sha2-nistp(256|384|521)) \S+/,
+          pattern: /^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521)) \S+/,
         },
       ],
       isRequired: true,

--- a/src/components/DeviceSummaryTile.js
+++ b/src/components/DeviceSummaryTile.js
@@ -27,13 +27,13 @@ const DeviceSummaryTileBase = ({
         <GridItem span={6}>
           <Stack hasGutter>
             <StackItem>
-              <Button isInline className="pf-u-pr-md" variant="link">
+              <Button isDisabled isInline className="pf-u-pr-md" variant="link">
                 {active}
               </Button>{' '}
               Active
             </StackItem>
             <StackItem>
-              <Button isInline className="pf-u-pr-md" variant="link">
+              <Button isDisabled isInline className="pf-u-pr-md" variant="link">
                 {orphaned}
               </Button>{' '}
               Orphaned
@@ -43,13 +43,13 @@ const DeviceSummaryTileBase = ({
         <GridItem span={6}>
           <Stack hasGutter>
             <StackItem>
-              <Button isInline className="pf-u-pr-md" variant="link">
+              <Button isDisabled isInline className="pf-u-pr-md" variant="link">
                 {noReports}
               </Button>
               Stale
             </StackItem>
             <StackItem>
-              <Button isInline className="pf-u-pr-md" variant="link">
+              <Button isDisabled isInline className="pf-u-pr-md" variant="link">
                 {neverReported}
               </Button>
               Registered but never reported


### PR DESCRIPTION
This PR contains two different tasks:
- Fix ssh validation regex to accept ssh-ed25519 format keys
- Disable clickable option in device summary counters 