### PR TITLE
Add Device Status column: Running, Booting, Unspecified

### DIFF
--- a/src/Routes/Devices/DeviceStatus.js
+++ b/src/Routes/Devices/DeviceStatus.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Split, SplitItem } from '@patternfly/react-core';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import InProgressIcon from '@patternfly/react-icons/dist/js/icons/in-progress-icon';
+import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
+import PropTypes from 'prop-types';
+
+const DeviceStatus = ({ systemProfile }) => {
+  console.debug('system profile is', systemProfile);
+  const { rpm_ostree_deployments } = systemProfile;
+  if (rpm_ostree_deployments?.length === undefined) {
+    return (
+      <Split>
+        <SplitItem className="pf-u-mr-sm">
+          <QuestionCircleIcon color="grey" />
+        </SplitItem>
+        <SplitItem>Unspecified</SplitItem>
+      </Split>
+    );
+  }
+  const current_deployment = rpm_ostree_deployments[0];
+  if (!current_deployment.booted) {
+    return (
+      <Split>
+        <SplitItem className="pf-u-mr-sm">
+          <InProgressIcon color="blue" />
+        </SplitItem>
+        <SplitItem>Booting</SplitItem>
+      </Split>
+    );
+  }
+  return (
+    <Split>
+      <SplitItem className="pf-u-mr-sm">
+        <CheckCircleIcon color="green" />
+      </SplitItem>
+      <SplitItem>Running</SplitItem>
+    </Split>
+  );
+};
+
+DeviceStatus.propTypes = {
+  systemProfile: PropTypes.shape({
+    rpm_ostree_deployments: PropTypes.arrayOf(
+      PropTypes.shape({
+        booted: PropTypes.bool,
+        checksum: PropTypes.string,
+      })
+    ),
+  }).isRequired,
+};
+
+export default DeviceStatus;

--- a/src/Routes/Devices/Devices.js
+++ b/src/Routes/Devices/Devices.js
@@ -23,6 +23,8 @@ import {
 } from '../../constants';
 import { Tiles } from '../../components/Tiles';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import DeviceStatus from './DeviceStatus';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 const CreateImageWizard = React.lazy(() =>
   import(
@@ -100,6 +102,29 @@ const Devices = () => {
           tableProps={{
             canSelectAll: false,
           }}
+          columns={() => {
+            return [
+              {
+                key: 'display_name',
+                title: 'Name',
+              },
+              {
+                key: 'updated',
+                title: 'Last seen',
+                // eslint-disable-next-line react/display-name
+                renderFunc: (dateStr) => <DateFormat date={dateStr} />,
+              },
+              {
+                key: 'system_profile',
+                title: 'Status',
+                // eslint-disable-next-line react/display-name
+                renderFunc: (sysProf) => (
+                  <DeviceStatus systemProfile={sysProf} />
+                ),
+                props: { width: 20, isStatic: true },
+              },
+            ];
+          }}
           getEntities={async (_i, config) => {
             const data = await getEntities(undefined, {
               ...config,
@@ -115,6 +140,10 @@ const Devices = () => {
                 system_profile: [
                   ...(config?.fields?.system_profile || []),
                   'host_type',
+                  'operating_system',
+                  'greenboot_status',
+                  'greenboot_fallback_detected',
+                  'rpm_ostree_deployments',
                 ],
               },
             });
@@ -143,6 +172,7 @@ const Devices = () => {
               },
             ],
           }}
+          hasCheckbox={false}
           activeFiltersConfig={{
             ...(isEmptyFilters(activeFilters) && {
               filters: constructActiveFilters(


### PR DESCRIPTION
Right now show only three type of statuses: running, booting and unspecified.

The unspecified will be shown if `rpm_ostree_deployment` is missing.