### PR TITLE
Wizard v2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2744,13 +2744,13 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.128.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.128.2.tgz",
-      "integrity": "sha512-EhrxE3+V7AYVhbERrcRVH7oY6TeVRqqzaRx8HXWnyn/hxE2rTzhhaLHyjotxk9mGYmIYtMuMebBHFbX0g+6Ymg==",
+      "version": "4.135.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.135.0.tgz",
+      "integrity": "sha512-DZcONUGOR7Znd6BsUJ4L+KrrnIpyjUvh3JNcYiHW3loytxShCGcx+a04QjOOcZm+MtFhkgs/t51yiC5IP12abA==",
       "requires": {
-        "@patternfly/react-icons": "^4.10.11",
-        "@patternfly/react-styles": "^4.10.11",
-        "@patternfly/react-tokens": "^4.11.12",
+        "@patternfly/react-icons": "^4.11.0",
+        "@patternfly/react-styles": "^4.11.0",
+        "@patternfly/react-tokens": "^4.12.0",
         "focus-trap": "6.2.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -2758,19 +2758,19 @@
       },
       "dependencies": {
         "@patternfly/react-icons": {
-          "version": "4.10.11",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.10.11.tgz",
-          "integrity": "sha512-Qyxwvghb9HZB2do3UVw4EzJSvqWaw/AEw6mFzqshZiIm2oPrL4NkvavwDt5WRicz5sbyWTZluB4grOj33PEpww=="
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.11.0.tgz",
+          "integrity": "sha512-WsIX34bO9rhVRmPG0jlV3GoFGfYgPC64TscNV0lxQosiVRnYIA6Z3nBSArtJsxo5Yn6c63glIefC/YTy6D/ZYg=="
         },
         "@patternfly/react-styles": {
-          "version": "4.10.11",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.10.11.tgz",
-          "integrity": "sha512-M+NhTtAXreJzMAV2Z1P2pbnKpRYnWbB5iZ6mxB0tkxxG+KyZ0/se8M5rUepLOE/n7BMq8IiOjPJ9zu/vpWj0gA=="
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.0.tgz",
+          "integrity": "sha512-4eIqTwGI4mjt9DMqX6hnan4eRS+3LUWNaneTEJdmk+flKxtAE/O/OmQHvH4GetDnlSbyfATcA0VFbVtR0aRJAg=="
         },
         "@patternfly/react-tokens": {
-          "version": "4.11.12",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.11.12.tgz",
-          "integrity": "sha512-PTEc2CQa/BqcDcUwT0V02l+ZoJa+bheLlh9R5g1+JQ6vlqH31gk0dpHmj6goEcSDLkbvMJgr3kNZdJsP1VdBMg=="
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.12.0.tgz",
+          "integrity": "sha512-Oj+GxqTtx0Yu9IDCTibZLQnpcKp58JneNKEFQkJ29WJydhPG4j6oFFElkK+ub+Ft/f9B1Ky1SsfR9eabo6IykQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@data-driven-forms/react-form-renderer": "^3.7.0",
     "@patternfly/patternfly": "4.70.2",
     "@patternfly/react-charts": "^6.12.12",
-    "@patternfly/react-core": "4.128.2",
+    "@patternfly/react-core": "4.135.0",
     "@patternfly/react-icons": "^4.7.22",
     "@patternfly/react-styles": "^4.7.22",
     "@patternfly/react-table": "4.19.45",

--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -108,8 +108,7 @@ const CreateImage = ({ navigateBack }) => {
             },
             showTitles: true,
             title: 'Create image',
-            crossroads: ['target-environment', 'release'],
-            description: 'Create RHEL for Edge image',
+            crossroads: ['target-environment', 'release', 'imageType'],
             // order in this array does not reflect order in wizard nav, this order is managed inside
             // of each step by `nextStep` property!
             fields: [

--- a/src/Routes/ImageManager/steps/imageOutput.js
+++ b/src/Routes/ImageManager/steps/imageOutput.js
@@ -9,10 +9,10 @@ import {
 } from '../../ImageManagerDetail/constants';
 
 export default {
-  title: 'Image output',
+  title: 'Options',
   name: 'imageOutput',
   nextStep: ({ values }) =>
-    values.imageType?.includes('rhel-edge-installer')
+    values?.imageType?.includes('rhel-edge-installer') || !values.imageType
       ? 'registration'
       : 'packages',
   fields: [
@@ -43,7 +43,7 @@ export default {
           label: imageTypeLabel,
         })
       ),
-      initialValue: ['rhel-edge-installer'],
+      initialValue: ['rhel-edge-installer', 'rhel-edge-commit'],
       clearedValue: [],
       validate: [{ type: validatorTypes.REQUIRED }],
     },

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -4,7 +4,7 @@ import { Text } from '@patternfly/react-core';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 
 export default {
-  title: 'Image details',
+  title: 'Details',
   name: 'imageSetDetails',
   nextStep: 'imageOutput',
   fields: [

--- a/src/Routes/ImageManager/steps/updateDetails.js
+++ b/src/Routes/ImageManager/steps/updateDetails.js
@@ -4,7 +4,7 @@ import { Text } from '@patternfly/react-core';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 
 export default {
-  title: 'Image details',
+  title: 'Details',
   name: 'imageSetDetails',
   nextStep: 'imageOutput',
   fields: [

--- a/src/Routes/ImageManagerDetail/constants.js
+++ b/src/Routes/ImageManagerDetail/constants.js
@@ -46,6 +46,6 @@ export const releaseMapper = {
 };
 
 export const imageTypeMapper = {
+  'rhel-edge-commit': 'RHEL for Edge Update',
   'rhel-edge-installer': 'RHEL for Edge Installer (.iso)',
-  'rhel-edge-commit': 'RHEL for Edge Commit (.tar)',
 };

--- a/src/components/ReviewSection.js
+++ b/src/components/ReviewSection.js
@@ -11,9 +11,9 @@ import PropTypes from 'prop-types';
 
 const ReviewSection = ({ title, data, testid }) => {
   return (
-    <Grid className="pf-u-pb-md" data-testid={testid} hasGutter>
+    <Grid className="pf-u-pb-xl" data-testid={testid} hasGutter>
       <GridItem span={12} hasGutter>
-        <Text component={TextVariants.h1}>{title}</Text>
+        <Text component={TextVariants.h2}>{title}</Text>
       </GridItem>
       {data.map(({ name, value }) => (
         <>

--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -1,7 +1,20 @@
 import React, { useCallback } from 'react';
-import { FormGroup, Checkbox } from '@patternfly/react-core';
+import {
+  FormGroup,
+  Checkbox,
+  TextContent,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import PropTypes from 'prop-types';
+
+const outputHelperText = {
+  'rhel-edge-commit':
+    'An OSTree commit is always created when building an image.',
+  'rhel-edge-installer':
+    'An installable version of the image is typically created with a brand new image.',
+};
 
 const ImageOutputCheckbox = (props) => {
   const { input } = useFieldApi(props);
@@ -25,13 +38,28 @@ const ImageOutputCheckbox = (props) => {
       isStack
     >
       {props.options.map(({ value, label }, index) => (
-        <Checkbox
-          key={index}
-          label={label}
-          id={value}
-          isChecked={input.value.includes(value)}
-          onChange={toggleCheckbox}
-        />
+        <>
+          <Checkbox
+            key={index}
+            label={label}
+            id={value}
+            isChecked={input.value.includes(value)}
+            onChange={toggleCheckbox}
+            isDisabled={value === 'rhel-edge-commit'}
+          />
+          <TextContent>
+            <Text component={TextVariants.small}>
+              {outputHelperText[value]}
+            </Text>
+            {value === 'rhel-edge-installer' && (
+              <Text component={TextVariants.p}>
+                <Text component={TextVariants.a} isVisitedLink href="#">
+                  Learn more about image types.
+                </Text>
+              </Text>
+            )}
+          </TextContent>
+        </>
       ))}
     </FormGroup>
   );

--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -5,18 +5,37 @@ import {
   TextContent,
   Text,
   TextVariants,
+  FormHelperText,
 } from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import PropTypes from 'prop-types';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import warningColor from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
+
+const WarningInstallerHelperText = () => (
+  <FormHelperText
+    isHidden={false}
+    className='pf-u-ml-xl'
+    icon={<ExclamationTriangleIcon color={warningColor.value} />}
+  >
+    Creating an installable version of your image increases the build time and
+    is not needed for updating existing devices. You can create an installable
+    version of this image later if you continue with this option
+  </FormHelperText>
+);
 
 const outputHelperText = {
   'rhel-edge-commit':
     'An OSTree commit is always created when building an image.',
   'rhel-edge-installer':
     'An installable version of the image is typically created with a brand new image.',
+  'rhel-edge-installer-warning': `Creating an installable version of your image increases the build time  \
+  and is not needed for updating existing devices. \n You can create an installable version of this image later if you continue with this option`,
 };
 
 const ImageOutputCheckbox = (props) => {
+  const { getState } = useFormApi();
   const { input } = useFieldApi(props);
   const toggleCheckbox = useCallback(
     (checked, event) => {
@@ -31,7 +50,7 @@ const ImageOutputCheckbox = (props) => {
 
   return (
     <FormGroup
-      label="Output type"
+      label='Output type'
       isHelperTextBeforeField
       hasNoPaddingTop
       isRequired
@@ -49,11 +68,21 @@ const ImageOutputCheckbox = (props) => {
           />
           <TextContent>
             <Text component={TextVariants.small}>
-              {outputHelperText[value]}
+              {getState()?.initialValues?.isUpdate &&
+              value === 'rhel-edge-installer' ? (
+                <WarningInstallerHelperText />
+              ) : (
+                outputHelperText[value]
+              )}
             </Text>
             {value === 'rhel-edge-installer' && (
-              <Text component={TextVariants.p}>
-                <Text component={TextVariants.a} isVisitedLink href="#">
+              <Text component={TextVariants.small}>
+                <Text
+                  className='pf-u-ml-xl'
+                  component={TextVariants.a}
+                  isVisitedLink
+                  href='#'
+                >
                   Learn more about image types.
                 </Text>
               </Text>

--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -8,6 +8,7 @@ import {
   HelperText,
   HelperTextItem,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import PropTypes from 'prop-types';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
@@ -79,9 +80,9 @@ const ImageOutputCheckbox = (props) => {
                   className="pf-u-ml-lg"
                   component={TextVariants.a}
                   isVisitedLink
-                  href="#"
                 >
                   Learn more about image types.
+                  <ExternalLinkAltIcon className="pf-u-ml-sm" />
                 </Text>
               </Text>
             )}

--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -5,24 +5,22 @@ import {
   TextContent,
   Text,
   TextVariants,
-  FormHelperText,
+  HelperText,
+  HelperTextItem,
 } from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import PropTypes from 'prop-types';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import warningColor from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 
 const WarningInstallerHelperText = () => (
-  <FormHelperText
-    isHidden={false}
-    className='pf-u-ml-xl'
-    icon={<ExclamationTriangleIcon color={warningColor.value} />}
-  >
-    Creating an installable version of your image increases the build time and
-    is not needed for updating existing devices. You can create an installable
-    version of this image later if you continue with this option
-  </FormHelperText>
+  <HelperText className="pf-u-ml-lg" hasIcon>
+    <HelperTextItem className="pf-u-pb-md" variant="warning" hasIcon>
+      Creating an installable version of your image increases the build time and
+      is not needed for updating existing devices. <br />
+      You can create an installable version of this image later if you continue
+      with this option
+    </HelperTextItem>
+  </HelperText>
 );
 
 const outputHelperText = {
@@ -30,8 +28,6 @@ const outputHelperText = {
     'An OSTree commit is always created when building an image.',
   'rhel-edge-installer':
     'An installable version of the image is typically created with a brand new image.',
-  'rhel-edge-installer-warning': `Creating an installable version of your image increases the build time  \
-  and is not needed for updating existing devices. \n You can create an installable version of this image later if you continue with this option`,
 };
 
 const ImageOutputCheckbox = (props) => {
@@ -50,7 +46,7 @@ const ImageOutputCheckbox = (props) => {
 
   return (
     <FormGroup
-      label='Output type'
+      label="Output type"
       isHelperTextBeforeField
       hasNoPaddingTop
       isRequired
@@ -67,21 +63,23 @@ const ImageOutputCheckbox = (props) => {
             isDisabled={value === 'rhel-edge-commit'}
           />
           <TextContent>
-            <Text component={TextVariants.small}>
-              {getState()?.initialValues?.isUpdate &&
-              value === 'rhel-edge-installer' ? (
-                <WarningInstallerHelperText />
-              ) : (
-                outputHelperText[value]
-              )}
-            </Text>
+            {getState()?.initialValues?.isUpdate &&
+            value === 'rhel-edge-installer' ? (
+              <WarningInstallerHelperText />
+            ) : (
+              <HelperText className="pf-u-ml-lg pf-u-pb-sm">
+                <HelperTextItem variant="indeterminate">
+                  {outputHelperText[value]}
+                </HelperTextItem>
+              </HelperText>
+            )}
             {value === 'rhel-edge-installer' && (
               <Text component={TextVariants.small}>
                 <Text
-                  className='pf-u-ml-xl'
+                  className="pf-u-ml-lg"
                   component={TextVariants.a}
                   isVisitedLink
-                  href='#'
+                  href="#"
                 >
                   Learn more about image types.
                 </Text>

--- a/src/components/form/Packages.js
+++ b/src/components/form/Packages.js
@@ -30,6 +30,12 @@ const Packages = ({ defaultArch, ...props }) => {
     setPackagesSelected(
       mapPackagesToComponent(getState()?.values?.[input.name] || [])
     );
+    const availableSearchInput = document.querySelector(
+      '[aria-label="Available search input"]'
+    );
+    availableSearchInput?.addEventListener('keydown', handleSearchOnEnter);
+    return () =>
+      availableSearchInput.removeEventListener('keydown', handleSearchOnEnter);
   }, []);
 
   const packageListChange = (newAvailablePackages, newChosenPackages) => {
@@ -46,6 +52,13 @@ const Packages = ({ defaultArch, ...props }) => {
       packagesSearchName.current
     );
     setPackagesAvailable(mapPackagesToComponent(data || []));
+  };
+
+  const handleSearchOnEnter = (e) => {
+    if (e.key === 'Enter') {
+      e.stopPropagation();
+      handlePackagesSearch();
+    }
   };
 
   return (


### PR DESCRIPTION
A draft for updating the Wizard for V2. 

Changes are
- Removed description under title for create wizard
- Changed step titles to match mockup
- Fixed registration bug where on create wizard registration step wasn't on by default
- Change tar text to update
- Added helper text to create wizard and update wizard
- Fixed bug for package input search where enter went to next step instead of search

Need review on
- updated patternfly from 4.128.2 -> 4.135.0 to include helper text and color class support
- on useEffect on package step add event listener for enter bug fix

@boaz0 Need your expert opinion! :smiley: 