### PR TITLE
Remove fields not returned by api in ImageDetailsTab

### DIFF
--- a/src/Routes/ImageManagerDetail/ImageDetailTab.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTab.js
@@ -24,8 +24,6 @@ const ImageDetailTab = () => {
     Release: () => distributionMapper[data['Distribution']],
     'Output type': () => imageTypeMapper[data['ImageType']],
     'Added packages': () => data.Commit.Packages.length,
-    'Base Packages': () => 0,
-    Dependencies: () => 0,
   };
 
   return (


### PR DESCRIPTION
### What's inside ?
- after discussion with backend team, we decided to remove not returned fields from api.

### How it is build?
- remove fields from labelsToValueMapper object.