### PR TITLE
Reset Pagination indicator on Handlesort

### DIFF
--- a/src/Routes/ImageManagerDetail/ImagePackagesTab.js
+++ b/src/Routes/ImageManagerDetail/ImagePackagesTab.js
@@ -109,6 +109,7 @@ const ImagePackagesTab = () => {
         ).slice(0, perPage)
       )
     );
+    setPage(0);
   };
 
   return (


### PR DESCRIPTION
### What's inside ?

- Fixed pagination indicator after resorted list

### How is it build ?

- reset  setPage on imagePackagesTab