### PR TITLE
Send output types to the backend as a list

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -288,6 +288,7 @@ export const createImage = ({
     description,
     distribution: release,
     imageType: imageType,
+    outputTypes: imageTypes,
     commit: {
       arch: architecture,
       packages: packages.map((item) => ({ name: item.name })),
@@ -332,8 +333,8 @@ export const fetchEdgeImages = (
     return value === undefined
       ? acc
       : acc === ''
-      ? `${value}`
-      : `${acc}&${value}`;
+        ? `${value}`
+        : `${acc}&${value}`;
   }, '');
 
   return instance.get(`${EDGE_API}/images?${query}`);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -333,8 +333,8 @@ export const fetchEdgeImages = (
     return value === undefined
       ? acc
       : acc === ''
-        ? `${value}`
-        : `${acc}&${value}`;
+      ? `${value}`
+      : `${acc}&${value}`;
   }, '');
 
   return instance.get(`${EDGE_API}/images?${query}`);


### PR DESCRIPTION
This will allow us to ship a change on the backend and do a non-breaking change. When we change the actual table, we can remove the ImageType from the request, but I'll leave that work for more skilled frontend devs. 

Related to https://github.com/RedHatInsights/edge-api/pull/211 and has to be merged and shipped to stage before the API PR.


Screenshots:

![Screenshot from 2021-08-24 13-33-47](https://user-images.githubusercontent.com/1480558/130655334-773a18ac-aa41-4b08-aa84-5221ba85aada.png)
![Screenshot from 2021-08-24 13-33-27](https://user-images.githubusercontent.com/1480558/130655336-7150aae2-c3d4-49f6-92e3-f0c1ca90b35d.png)
