### PR TITLE
Have getDeviceHasUpdate fail gracefully

### DIFF
--- a/src/Routes/Devices/Devices.js
+++ b/src/Routes/Devices/Devices.js
@@ -174,7 +174,9 @@ const Devices = () => {
             const promises = defaultData.results.map(async (device) => {
               const getImageInfo = await getDeviceHasUpdate(device.id);
               const imageInfo =
-                getImageInfo === 404 ? { data: null } : getImageInfo;
+                !getImageInfo || getImageInfo === 404
+                  ? { data: null }
+                  : getImageInfo;
               return {
                 ...device,
                 system_profile: {


### PR DESCRIPTION
When getDeviceHasUpdate fails we should still load the device table and avoid the page erroring out.