### PR TITLE
Add api call and async validation to image name in create image wizard

### DIFF
--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -2,9 +2,28 @@ import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import { Text } from '@patternfly/react-core';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-
+import { checkImageName } from '../../../api';
 const helperText =
   'Can only contain letters, numbers, hyphens(-), and underscores(_).';
+
+const asyncImageNameValidation = (value) =>
+  new Promise((resolve, reject) => {
+    if (value !== undefined) {
+      checkImageName(value)
+        .then((response) =>
+          response
+            ? reject({ message: 'Name already exists' })
+            : resolve({ message: 'validation succesfull' })
+        )
+        .catch(() =>
+          reject({
+            message: 'Cannot validate name in server, please try again later',
+          })
+        );
+    }
+  }).catch(({ message }) => {
+    throw message;
+  });
 
 export default {
   title: 'Details',
@@ -27,6 +46,7 @@ export default {
       placeholder: 'Image name',
       helperText: helperText,
       validate: [
+        asyncImageNameValidation,
         { type: validatorTypes.REQUIRED },
         {
           type: validatorTypes.PATTERN,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -369,3 +369,10 @@ export const updateDeviceLatestImage = async (payload) => {
 export const getImageDataOnDevice = (id) => {
   return instance.get(`${EDGE_API}/updates/device/${id}/image`);
 };
+
+export const checkImageName = (name) => {
+  const payload = {
+    name,
+  };
+  return instance.post(`${EDGE_API}/images/checkImageName`, payload);
+};


### PR DESCRIPTION
### What is inside?
Add validation to check if new image name is already in use while user is typing the new name.

### How is it build?
- Create an api connection to use new check name api
- Add an async validator to image name component in Create Wizard
- Add async method to validate and handle the promise status in async validator 

### Additional Comments

## DO NOT MERGE THIS PR until backend PR solving api issue is merged and deployed, this will block the create of new images, see details below:

During develop this, I found an error in new endpoint, this error consists in a error 500 everytime that the new name is not present in the database, this PR is intend to solve this issue: https://github.com/RedHatInsights/edge-api/pull/299 , PLEASE, JUST MERGE THIS PR AFTER 299 IS MERGED TO BACKEND

