### PR TITLE
fix empty state for actions for images and devices

### DIFF
--- a/src/Routes/Devices/Devices.js
+++ b/src/Routes/Devices/Devices.js
@@ -114,11 +114,13 @@ const Devices = () => {
                       },
                     },
                   ]
-                : [
+                : rowData?.system_profile
+                ? [
                     {
                       title: 'No Action',
                     },
-                  ];
+                  ]
+                : null;
             },
             areActionsDisabled: (rowData) => {
               const updateTransactions =

--- a/src/Routes/ImageManager/ImageTable.js
+++ b/src/Routes/ImageManager/ImageTable.js
@@ -136,7 +136,7 @@ const ImageTable = ({ openCreateWizard, openUpdateWizard }) => {
       });
     }
 
-    if (rowData?.imageStatus !== 'SUCCESS') {
+    if (rowData?.imageStatus !== 'SUCCESS' && rowData?.id) {
       actionsArray.push({
         title: '',
       });

--- a/src/Routes/ImageManager/ImageTable.js
+++ b/src/Routes/ImageManager/ImageTable.js
@@ -98,7 +98,7 @@ const ImageTable = ({ openCreateWizard, openUpdateWizard }) => {
   );
   const { count, data, isLoading, hasError } = useSelector(
     ({ edgeImagesReducer }) => ({
-      count: edgeImagesReducer?.data?.count,
+      count: edgeImagesReducer?.data?.count || 0,
       data: edgeImagesReducer?.data?.data || null,
       isLoading:
         edgeImagesReducer?.isLoading === undefined


### PR DESCRIPTION
Fix empty state for actions for images and devices. Remove kebab when image and device tables have no row data.