### PR TITLE
fixed update device modal bug

### DIFF
--- a/src/Routes/Devices/UpdateDeviceModal.js
+++ b/src/Routes/Devices/UpdateDeviceModal.js
@@ -22,10 +22,8 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
   const dispatch = useDispatch();
   const imageData =
     updateModal.deviceData?.system_profile?.image_data?.ImageInfo
-      ?.UpdatesAvailable[
-      updateModal.deviceData?.system_profile?.image_data?.ImageInfo
-        ?.UpdatesAvailable.length - 1
-    ];
+      ?.UpdatesAvailable[0];
+
   const handleUpdateModal = async () => {
     try {
       await updateDeviceLatestImage({


### PR DESCRIPTION
Latest available image update is ordered as the first index in the array instead of the last. Changed order in which we are setting modal image data