### PR TITLE
modify ImageDetailTab to handle new api response 

### DIFF
--- a/src/Routes/ImageManagerDetail/ImageDetailTab.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTab.js
@@ -23,12 +23,9 @@ const ImageDetailTab = ({
   const [packageData, setPackageData] = useState({});
 
   useEffect(() => {
-    let dataToMerge = isVersionDetails ? imageData : imageData?.data;
-    let mergedData = {
-      ...dataToMerge,
-      ...dataToMerge?.Images[dataToMerge?.Images.length - 1],
-    };
-    setData(mergedData);
+    setData(
+      isVersionDetails ? imageData : imageData?.data ? imageData?.data[0] : []
+    );
   }, [imageData]);
 
   useEffect(() => {

--- a/src/Routes/ImageManagerDetail/ImageVersionsTab.js
+++ b/src/Routes/ImageManagerDetail/ImageVersionsTab.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import GeneralTable from '../../components/general-table/GeneralTable';
 import PropTypes from 'prop-types';
 import { routes as paths } from '../../../package.json';
@@ -30,7 +30,7 @@ const columnNames = [
 ];
 
 const createRows = (data) => {
-  return data.Images.map((image) => ({
+  return data.map((image) => ({
     id: image.ID,
     noApiSortFilter: [
       image?.Version,
@@ -62,6 +62,13 @@ const createRows = (data) => {
 };
 
 const ImageVersionsTab = ({ imageData, openUpdateWizard }) => {
+  const [rows, setRows] = useState([]);
+  useEffect(() => {
+    if (imageData?.data) {
+      setRows(createRows(imageData?.data));
+    }
+  }, [imageData]);
+
   const actionResolver = (rowData) => {
     const actionsArray = [];
     if (rowData?.isoURL) {
@@ -113,7 +120,7 @@ const ImageVersionsTab = ({ imageData, openUpdateWizard }) => {
         hasError: imageData?.hasError,
       }}
       columnNames={columnNames}
-      rows={imageData?.data ? createRows(imageData?.data) : []}
+      rows={rows}
       actionResolver={actionResolver}
       areActionsDisabled={areActionsDisabled}
       defaultSort={{ index: 2, direction: 'desc' }}


### PR DESCRIPTION
### What is inside?
- Modify data on ImageDetailTab to avoid broken screen with new api response
- Create state to manage rows in ImageVersionsTab 

### How is build? 
- change the data return from merged object to a plain object in array get position 0
- add new hooks to control state
- call this update after create rows in version tab

Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>