### PR TITLE
Allow Cypress to use different config files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
 install-deps:
-	npm install
+	npm install --save-dev start-server-and-test
 
 open-cypress:
-	npx cypress open
+	npx cypress open --env configFile=local
+
+test-local:
+	BETA=true npm run start:proxy
+	$(npm bin)/cypress open --env configFile=local
+
+test-prod:
+	npx cypress run --env configFile=prod
+
+test-stage:
+	npx cypress run --env configFile=stage
 
 tests:
 	npx cypress run
 
-.PHONY: help install-deps open-cypress tests
+.PHONY: help install-deps open-cypress test-local test-prod test-stage tests

--- a/cypress/integration/smoke/login.spec.js
+++ b/cypress/integration/smoke/login.spec.js
@@ -1,28 +1,29 @@
 /// <reference types="cypress" />
 
 describe('simple login to fleet management', () => {
-  beforeEach(() => {
-    // Cypress starts out with a blank slate for each test
-    // so we must tell it to visit our website with the `cy.visit()` command.
-    // Since we want to visit the same URL at the start of all our tests,
-    // we include it in our beforeEach function so that it runs before each test
+    beforeEach(() => {
+        // Cypress starts out with a blank slate for each test
+        // so we must tell it to visit our website with the `cy.visit()` command.
+        // Since we want to visit the same URL at the start of all our tests,
+        // we include it in our beforeEach function so that it runs before each test
 
-    const APP_ENV = Cypress.env('app_env');
-    cy.visit(Cypress.env(`${APP_ENV}_host`));
-  });
+        //const APP_ENV = Cypress.env('app_env');
+        //cy.visit(Cypress.env(`${APP_ENV}_host`));
+        cy.visit(Cypress.config().baseUrl)
+    });
 
-  it('displays an error during the initial login page', () => {
-    // We use the `cy.get()` command to get all elements that match the selector.
-    // Then, we use `should` to assert that there are two matched items,
-    // which are the two default items.
-    const userName = 'Feed the cat';
-    const userPassword = 'Meow';
-    const failedLogin = 'Invalid login or password';
+    it('displays an error during the initial login page', () => {
+        const userName = Cypress.env('username');
+        const userPassword = Cypress.env('password');
+        const failedLogin = 'Invalid login or password';
 
-    cy.waitFor('#username-verification');
-    cy.get('#username-verification').type(`${userName}{enter}`);
-    cy.waitFor('#password');
-    cy.get('#password').type(`${userPassword}{enter}`);
-    cy.get('#rh-login-form-error-title').should('contain', failedLogin);
-  });
+        cy.waitFor('#username-verification');
+        cy.get('#username-verification')
+            .type(`${userName}{enter}`);
+        cy.waitFor('#password');
+        cy.get('#password')
+            .type(`${userPassword}{enter}`);
+        cy.get('#rh-login-form-error-title')
+            .should('contain', failedLogin);
+    });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -16,7 +16,19 @@
  * @type {Cypress.PluginConfig}
  */
 // eslint-disable-next-line no-unused-vars
+const fs = require('fs-extra');
+const path = require('path');
+
+function getConfigurationByFile(file) {
+    const pathToConfigFile = path.resolve('cypress/config', `${file}.env.json`);
+
+    return fs.readJson(pathToConfigFile)
+}
+
+// plugins file
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+    // accept a configFile value or use local by default
+    const file = config.env.configFile || 'local';
+
+    return getConfigurationByFile(file)
 }


### PR DESCRIPTION
This PR adds support for passing different configuration files to Cypress.

Configuration files can be added under the `cypress/config` directory and
should be named using the naming format `<ENV_NAME>.env.js`. If none is
provided, then cypress will attempt to load `cypress/config/local.env.js` as
the default.

Signed-off-by: Og B. Maciel <omaciel@ogmaciel.com>