### PR TITLE
fixed bug on package step

### DIFF
--- a/src/components/form/Packages.js
+++ b/src/components/form/Packages.js
@@ -186,11 +186,12 @@ const Packages = ({ defaultArch, ...props }) => {
     if (fromAvailable) {
       setAvailableOptions(sortedOptions([...sourceOptions]));
       setChosenOptions(destinationOptions);
+      change(input.name, destinationOptions);
     } else {
       setChosenOptions(sortedOptions([...sourceOptions]));
       setAvailableOptions(destinationOptions);
+      change(input.name, [...sourceOptions]);
     }
-    change(input.name, chosenOptions);
     setScrollTo({
       pkgs: selectedOptions,
       pane: fromAvailable ? 'chosen' : 'available',
@@ -209,7 +210,7 @@ const Packages = ({ defaultArch, ...props }) => {
       setAvailableOptions(
         sortedOptions([...availableOptions.filter((x) => !x.isVisible)])
       );
-      change(input.name, availableOptions);
+      change(input.name, [...availableOptions, ...chosenOptions]);
     } else {
       setAvailableOptions(
         sortedOptions([


### PR DESCRIPTION
# Description
Fixes bug on package step in the wizard
- removing a previously added package and then adding that package back in wasn't tracked
- properly tracking adding and removing of packages

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted