### PR TITLE
verify if config file exist before returning it to cypress

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -19,28 +19,19 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-async function getConfigurationByFile(file) {
+function getConfigurationByFile(file) {
   const pathToConfigFile = path.resolve('cypress/config', `${file}.env.json`);
   // check if file exists
   if (!fs.existsSync(pathToConfigFile)) {
     throw new Error(`Config file ${pathToConfigFile} does not exist`);
   }
-  return pathToConfigFile;
+
+  return fs.readJson(pathToConfigFile);
 }
 
 // plugins file
 module.exports = (on, config) => {
   // accept a configFile value or use local by default
   const file = config.env.configFile || 'local';
-  getConfigurationByFile(file)
-    .then((pathToConfigFile) => {
-      console.log(`Using config file: ${pathToConfigFile}`);
-      config.configFile = pathToConfigFile;
-    })
-    .catch((err) => {
-      console.log(err);
-      throw new Error(err);
-    });
-
-  return config;
+  return getConfigurationByFile(file);
 };

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -19,16 +19,28 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-function getConfigurationByFile(file) {
-    const pathToConfigFile = path.resolve('cypress/config', `${file}.env.json`);
-
-    return fs.readJson(pathToConfigFile)
+async function getConfigurationByFile(file) {
+  const pathToConfigFile = path.resolve('cypress/config', `${file}.env.json`);
+  // check if file exists
+  if (!fs.existsSync(pathToConfigFile)) {
+    throw new Error(`Config file ${pathToConfigFile} does not exist`);
+  }
+  return pathToConfigFile;
 }
 
 // plugins file
 module.exports = (on, config) => {
-    // accept a configFile value or use local by default
-    const file = config.env.configFile || 'local';
+  // accept a configFile value or use local by default
+  const file = config.env.configFile || 'local';
+  getConfigurationByFile(file)
+    .then((pathToConfigFile) => {
+      console.log(`Using config file: ${pathToConfigFile}`);
+      config.configFile = pathToConfigFile;
+    })
+    .catch((err) => {
+      console.log(err);
+      throw new Error(err);
+    });
 
-    return getConfigurationByFile(file)
-}
+  return config;
+};


### PR DESCRIPTION
# Description

~I noticed that even exporting  `--env configFile=local` on makefile, cypress was using the default config file `cyress.json` not the local one. With this PR cypress will load the proper `env.json` as configFile (based on environment) instead.~

_EDIT_ reverted to use the default cypress way to override config files

Added just the verification to check if config file exist instead
 

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted