### PR TITLE
changed empty state for available packages when search is too broad

### DIFF
--- a/src/components/form/Packages.js
+++ b/src/components/form/Packages.js
@@ -65,6 +65,7 @@ const Packages = ({ defaultArch, ...props }) => {
   const [hasMoreResults, setHasMoreResults] = useState(false);
   const [scrollTo, setScrollTo] = useState(null);
   const [hasNoSearchResults, setHasNoSearchResults] = useState(false);
+  const [searchFocused, setSearchFocused] = useState(false);
 
   useEffect(() => {
     const loadedPackages = getState()?.values?.[input.name] || [];
@@ -110,6 +111,7 @@ const Packages = ({ defaultArch, ...props }) => {
 
     if (meta.count > 100) {
       setHasMoreResults(true);
+      return;
     } else setHasMoreResults(false);
 
     const removeChosenPackages = data.filter(
@@ -258,7 +260,11 @@ const Packages = ({ defaultArch, ...props }) => {
             type="search"
             onChange={onChange}
             placeholder="Search for packages"
-            validated={hasMoreResults && isAvailable ? 'warning' : ''}
+            onFocus={() => setSearchFocused(true)}
+            onBlur={() => setSearchFocused(false)}
+            validated={
+              hasMoreResults && isAvailable && !searchFocused ? 'warning' : ''
+            }
             aria-label={
               isAvailable ? 'available search input' : 'chosen search input'
             }
@@ -285,7 +291,7 @@ const Packages = ({ defaultArch, ...props }) => {
         {hasMoreResults && isAvailable && (
           <HelperText>
             <HelperTextItem variant="warning">
-              First 100 results displayed. Please, refine your search
+              First 100 results displayed. Refine your search
             </HelperTextItem>
           </HelperText>
         )}
@@ -339,6 +345,11 @@ const Packages = ({ defaultArch, ...props }) => {
             <NoResultsText
               heading="No Results Found"
               body="Adjust your search and try again"
+            />
+          ) : hasMoreResults ? (
+            <NoResultsText
+              heading="Too many results to display"
+              body="Please make the search more specific and try again"
             />
           ) : (
             <EmptyText text="Search above to add additional packages to your image." />


### PR DESCRIPTION
# Description

Change the behavior of how a search result that yields too broad of results.
- Adds warning text to input and hides on focus
- Adds empty state to available pane instead of packages so the user cannot add any until the search is more granular

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted