### PR TITLE
Add node and npm versions that work on repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,10 @@
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "4.9.1",
         "webpack-dev-server": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=16.13.0 <= 16.13.1",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,10 @@
     "webpack-cli": "4.9.1",
     "webpack-dev-server": "^4.5.0"
   },
+  "engines": {
+    "node": ">=16.13.0 <= 16.13.1",
+    "npm": ">=7.0.0"
+  },
   "insights": {
     "appname": "edge"
   },


### PR DESCRIPTION
# Description

Add config to package.json of working node and npm versions that are need for the repo to work.
If a users has the wrong version of node and/or npm they will get a warning.

Here's a link to the npm docs about package.json engines: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted