### PR TITLE
fixed loading issue with update wizard

### DIFF
--- a/src/Routes/ImageManager/UpdateImageWizard.js
+++ b/src/Routes/ImageManager/UpdateImageWizard.js
@@ -8,7 +8,7 @@ import {
   registration,
   imageOutput,
 } from './steps';
-import { Spinner } from '@patternfly/react-core';
+import { Bullseye, Backdrop, Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import ReviewStep from '../../components/form/ReviewStep';
 import {
@@ -56,7 +56,7 @@ const UpdateImage = ({ navigateBack, updateImageID }) => {
     })();
   }, []);
 
-  return user ? (
+  return user && data ? (
     <ImageCreator
       onClose={closeAction}
       customComponentMapper={{
@@ -175,7 +175,11 @@ const UpdateImage = ({ navigateBack, updateImageID }) => {
       }}
     />
   ) : (
-    <Spinner />
+    <Backdrop>
+      <Bullseye>
+        <Spinner isSVG diameter="100px" />
+      </Bullseye>
+    </Backdrop>
   );
 };
 

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -4,6 +4,7 @@ import { Flex, FlexItem, Text } from '@patternfly/react-core';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import { checkImageName } from '../../../api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+
 const helperText =
   'Can only contain letters, numbers, spaces, hyphens(-), and underscores(_).';
 


### PR DESCRIPTION
# Description

Fixed an issue where the update wizard would flash (rerender) twice once on load and again on retrieving data. Fixed undesirable state where the image name would be undefined.

Solution was to add a backdrop and spinner while data is being fetched and only render once data is returned

Fixes # (issue)
https://issues.redhat.com/browse/THEEDGE-1105

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted