### PR TITLE
fixed bug - loading repo data into edit / remove modal

### DIFF
--- a/src/Routes/Repositories/RepositoryTable.js
+++ b/src/Routes/Repositories/RepositoryTable.js
@@ -8,15 +8,16 @@ const filters = [{ label: 'Name', type: 'text' }];
 
 const RepositoryTable = ({ data, openModal }) => {
   const actionResolver = (rowData) => {
+    const { id, repoName, repoBaseURL } = rowData;
     return [
       {
         title: 'Edit',
         onClick: () =>
           openModal({
             type: 'edit',
-            id: rowData.id,
-            name: rowData.rowName,
-            baseURL: rowData.baseURL,
+            id: id,
+            name: repoName,
+            baseURL: repoBaseURL,
           }),
       },
       {
@@ -24,9 +25,9 @@ const RepositoryTable = ({ data, openModal }) => {
         onClick: () =>
           openModal({
             type: 'remove',
-            id: rowData.id,
-            name: rowData.rowName,
-            baseURL: rowData.baseURL,
+            id: id,
+            name: repoName,
+            baseURL: repoBaseURL,
           }),
       },
     ];
@@ -35,6 +36,8 @@ const RepositoryTable = ({ data, openModal }) => {
   const buildRows = data.map(({ id, name, baseURL }) => {
     return {
       id: id,
+      repoName: name,
+      repoBaseURL: baseURL,
       noApiSortFilter: [name, baseURL],
       cells: [
         {


### PR DESCRIPTION
# Description

Fixed issue where repo data wasn't being loaded into the edit / remove modals. 

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted