### PR TITLE
Disable cve button when no cves

### DIFF
--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -53,7 +53,7 @@ const VulnerabilityTab = ({ imageId }) => {
           'cvss_score',
           'advisory',
         ]}
-        customAction={cve =>
+        customAction={(cve) => (
           <Button
             onClick={openUpdateWizard}
             variant="primary"
@@ -61,7 +61,7 @@ const VulnerabilityTab = ({ imageId }) => {
           >
             Update image
           </Button>
-        }
+        )}
       />
       {isUpdateWizardOpen && (
         <Suspense

--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -53,11 +53,11 @@ const VulnerabilityTab = ({ imageId }) => {
           'cvss_score',
           'advisory',
         ]}
-        customAction={
+        customAction={cve =>
           <Button
             onClick={openUpdateWizard}
             variant="primary"
-            isDisabled={!imageId}
+            isDisabled={!imageId || !cve?.meta?.cvesCount > 0}
           >
             Update image
           </Button>


### PR DESCRIPTION
# Description
Add callback to check the count of CVEs and disable 'update image' button in vulnerability tab in device details if no CVEs are present.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted