### PR TITLE
added ability to navigate to image set detail tabs from url

### DIFF
--- a/src/Routes/ImageManagerDetail/ImageDetail.js
+++ b/src/Routes/ImageManagerDetail/ImageDetail.js
@@ -112,6 +112,7 @@ const ImageDetail = () => {
         urlParam={imageId}
         imageVersion={imageVersion}
         openUpdateWizard={openUpdateWizard}
+        isLoading={imageSetData.isLoading}
       />
       {updateWizard.isOpen && (
         <Suspense

--- a/src/Routes/ImageManagerDetail/ImageDetailTabs.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTabs.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Tabs, Tab, TabTitleText, Skeleton } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import ImageDetailTab from './ImageDetailTab';
 import ImageVersionTab from './ImageVersionsTab';
@@ -20,15 +20,24 @@ const ImageDetailTabs = ({
   imageVersion,
   isLoading,
 }) => {
-  const { location } = useHistory();
+  const location = useLocation();
+  const history = useHistory();
   const [activeTabKey, setActiveTabkey] = useState(tabs.details);
-  const handleTabClick = (_event, tabIndex) => setActiveTabkey(tabIndex);
+
+  const paramIndex = imageVersion ? 4 : 3;
+  const url = location.pathname.split('/');
+
+  const handleTabClick = (_event, tabIndex) => {
+    const selectedTab =
+      tabIndex === 0 ? 'details' : imageVersion ? 'packages' : 'versions';
+
+    url[paramIndex] = selectedTab;
+    history.push(url.join('/'));
+
+    setActiveTabkey(tabIndex);
+  };
 
   useEffect(() => {
-    console.log(activeTabKey);
-    const paramIndex = imageVersion ? 4 : 3;
-    const url = location.pathname.split('/');
-
     if (paramIndex > url.length - 1) {
       setActiveTabkey(tabs.details);
       return;

--- a/src/Routes/ImageManagerDetail/ImageDetailTabs.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTabs.js
@@ -1,14 +1,41 @@
-import React, { useState } from 'react';
-import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import React, { useState, useEffect } from 'react';
+import { Tabs, Tab, TabTitleText, Skeleton } from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
 
 import ImageDetailTab from './ImageDetailTab';
 import ImageVersionTab from './ImageVersionsTab';
 import ImagePackagesTab from './ImagePackagesTab';
 import PropTypes from 'prop-types';
 
-const ImageDetailTabs = ({ imageData, openUpdateWizard, imageVersion }) => {
-  const [activeTabKey, setActiveTabkey] = useState(0);
+// conditional render for same index
+const tabs = {
+  details: 0,
+  packages: 1,
+  versions: 1,
+};
+
+const ImageDetailTabs = ({
+  imageData,
+  openUpdateWizard,
+  imageVersion,
+  isLoading,
+}) => {
+  const { location } = useHistory();
+  const [activeTabKey, setActiveTabkey] = useState(tabs.details);
   const handleTabClick = (_event, tabIndex) => setActiveTabkey(tabIndex);
+
+  useEffect(() => {
+    console.log(activeTabKey);
+    const paramIndex = imageVersion ? 4 : 3;
+    const url = location.pathname.split('/');
+
+    if (paramIndex > url.length - 1) {
+      setActiveTabkey(tabs.details);
+      return;
+    }
+    const lowerTab = url[paramIndex].toLowerCase();
+    setActiveTabkey(tabs[lowerTab] || tabs.details);
+  }, [imageVersion]);
 
   return (
     <div className="edge-c-device--detail add-100vh">
@@ -17,15 +44,33 @@ const ImageDetailTabs = ({ imageData, openUpdateWizard, imageVersion }) => {
         activeKey={activeTabKey}
         onSelect={handleTabClick}
       >
-        <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>}>
+        <Tab
+          eventKey={tabs.details}
+          title={<TabTitleText>Details</TabTitleText>}
+        >
           <ImageDetailTab imageData={imageData} imageVersion={imageVersion} />
         </Tab>
-        {imageVersion ? (
-          <Tab eventKey={1} title={<TabTitleText>Packages</TabTitleText>}>
+        {isLoading ? (
+          <Tab
+            title={
+              <TabTitleText>
+                {' '}
+                <Skeleton width="75px" />
+              </TabTitleText>
+            }
+          ></Tab>
+        ) : imageVersion ? (
+          <Tab
+            eventKey={tabs.packages}
+            title={<TabTitleText>Packages</TabTitleText>}
+          >
             <ImagePackagesTab imageVersion={imageVersion} />
           </Tab>
         ) : (
-          <Tab eventKey={1} title={<TabTitleText>Versions</TabTitleText>}>
+          <Tab
+            eventKey={tabs.versions}
+            title={<TabTitleText>Versions</TabTitleText>}
+          >
             <ImageVersionTab
               imageData={imageData}
               openUpdateWizard={openUpdateWizard}
@@ -41,6 +86,7 @@ ImageDetailTabs.propTypes = {
   imageData: PropTypes.object,
   imageVersion: PropTypes.object,
   openUpdateWizard: PropTypes.func,
+  isLoading: PropTypes.bool,
 };
 
 export default ImageDetailTabs;

--- a/src/Routes/ImageManagerDetail/ImageDetailTabs.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTabs.js
@@ -32,7 +32,12 @@ const ImageDetailTabs = ({
       tabIndex === 0 ? 'details' : imageVersion ? 'packages' : 'versions';
 
     splitUrl[paramIndex] = selectedTab;
-    history.push(splitUrl.join('/'));
+
+    if (selectedTab === 'details') {
+      history.push(splitUrl.splice(0, 5).join('/'));
+    } else {
+      history.push(splitUrl.join('/'));
+    }
 
     setActiveTabkey(tabIndex);
   };

--- a/src/Routes/ImageManagerDetail/ImageDetailTabs.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTabs.js
@@ -25,24 +25,24 @@ const ImageDetailTabs = ({
   const [activeTabKey, setActiveTabkey] = useState(tabs.details);
 
   const paramIndex = imageVersion ? 4 : 3;
-  const url = location.pathname.split('/');
+  const splitUrl = location.pathname.split('/');
 
   const handleTabClick = (_event, tabIndex) => {
     const selectedTab =
       tabIndex === 0 ? 'details' : imageVersion ? 'packages' : 'versions';
 
-    url[paramIndex] = selectedTab;
-    history.push(url.join('/'));
+    splitUrl[paramIndex] = selectedTab;
+    history.push(splitUrl.join('/'));
 
     setActiveTabkey(tabIndex);
   };
 
   useEffect(() => {
-    if (paramIndex > url.length - 1) {
+    if (paramIndex > splitUrl.length - 1) {
       setActiveTabkey(tabs.details);
       return;
     }
-    const lowerTab = url[paramIndex].toLowerCase();
+    const lowerTab = splitUrl[paramIndex].toLowerCase();
     setActiveTabkey(tabs[lowerTab] || tabs.details);
   }, [imageVersion]);
 

--- a/src/Routes/ImageManagerDetail/ImagePackagesTab.js
+++ b/src/Routes/ImageManagerDetail/ImagePackagesTab.js
@@ -4,6 +4,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import GeneralTable from '../../components/general-table/GeneralTable';
 import PropTypes from 'prop-types';
 import { cellWidth } from '@patternfly/react-table';
+import { useHistory, useLocation } from 'react-router-dom';
 
 const defaultFilters = [{ label: 'Name', type: 'text' }];
 
@@ -71,13 +72,29 @@ const createRows = (data, imageData, toggleTable) => {
   }));
 };
 
+const tabs = {
+  0: 'additional',
+  1: 'all',
+};
+
 const ImagePackagesTab = ({ imageVersion }) => {
   const [packageData, setPackageData] = useState({});
   const [toggleTable, setToggleTable] = useState(1);
 
+  const location = useLocation();
+  const history = useHistory();
+
   useEffect(() => {
     setPackageData(imageVersion);
   }, [imageVersion]);
+
+  useEffect(() => {
+    const splitUrl = location.pathname.split('/');
+    splitUrl.length === 6
+      ? (splitUrl[5] = tabs[toggleTable])
+      : splitUrl.push(tabs[toggleTable]);
+    history.push(splitUrl.join('/'));
+  }, [toggleTable]);
 
   return (
     <GeneralTable

--- a/src/Routes/ImageManagerDetail/ImagePackagesTab.js
+++ b/src/Routes/ImageManagerDetail/ImagePackagesTab.js
@@ -90,9 +90,16 @@ const ImagePackagesTab = ({ imageVersion }) => {
 
   useEffect(() => {
     const splitUrl = location.pathname.split('/');
-    splitUrl.length === 6
-      ? (splitUrl[5] = tabs[toggleTable])
-      : splitUrl.push(tabs[toggleTable]);
+    const currentTab = splitUrl[4].toLowerCase();
+
+    if (currentTab === 'packages') {
+      if (splitUrl.length === 6) {
+        splitUrl[5] = tabs[toggleTable];
+      } else {
+        splitUrl.push(tabs[toggleTable]);
+      }
+    }
+
     history.push(splitUrl.join('/'));
   }, [toggleTable]);
 

--- a/src/Routes/ImageManagerDetail/ImageVersionsTab.js
+++ b/src/Routes/ImageManagerDetail/ImageVersionsTab.js
@@ -62,7 +62,9 @@ const createRows = (data, imageSetId) => {
     cells: [
       {
         title: (
-          <Link to={`${paths['manage-images']}/${imageSetId}/${image.ID}`}>
+          <Link
+            to={`${paths['manage-images']}/${imageSetId}/${image.ID}/details`}
+          >
             {image?.Version}
           </Link>
         ),

--- a/src/components/general-table/GeneralTable.test.js
+++ b/src/components/general-table/GeneralTable.test.js
@@ -6,6 +6,7 @@ import { init, RegistryContext } from '../../store';
 import { render } from '@testing-library/react';
 import logger from 'redux-logger';
 
+import { MemoryRouter } from 'react-router-dom';
 describe('General table', () => {
   it('should render correctly', async () => {
     const filters = [
@@ -69,7 +70,8 @@ describe('General table', () => {
             ]}
           />
         </Provider>
-      </RegistryContext.Provider>
+      </RegistryContext.Provider>,
+      { wrapper: MemoryRouter }
     );
 
     const generalTableHeader = await findByTestId('toolbar-header-testid');


### PR DESCRIPTION
# Description

Added ability to navigate to each individual tab in the image set detail view

Fixes # (issue)
https://issues.redhat.com/browse/THEEDGE-1465

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted