### PR TITLE
fix width to clipboard item on ImageSets Details

### DIFF
--- a/src/Routes/ImageManagerDetail/ImageDetailTab.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTab.js
@@ -111,7 +111,7 @@ const ImageDetailTab = ({ imageData, imageVersion }) => {
   return (
     <TextContent className="pf-u-ml-lg pf-u-mt-md">
       <Grid span={12}>
-        <GridItem span={6}>
+        <GridItem span={5}>
           <Text component={TextVariants.h2}>
             {imageVersion ? 'Details' : 'Most recent image'}
           </Text>
@@ -123,6 +123,7 @@ const ImageDetailTab = ({ imageData, imageVersion }) => {
             {buildTextList(userInfoMapper) || createSkeleton(2)}
           </TextList>
         </GridItem>
+        <GridItem span={1} />
         <GridItem span={6}>
           <Text component={TextVariants.h2}>Packages </Text>
           <TextList component={TextListVariants.dl}>


### PR DESCRIPTION
Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

# Description
Space between clipboard item and gridItem

Fixes # (iTHEEDGE-1468) https://issues.redhat.com/browse/THEEDGE-1083

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted