### PR TITLE
fixed package tab for loading with additional text in url

### DIFF
--- a/src/Routes/ImageManagerDetail/ImagePackagesTab.js
+++ b/src/Routes/ImageManagerDetail/ImagePackagesTab.js
@@ -72,31 +72,37 @@ const createRows = (data, imageData, toggleTable) => {
   }));
 };
 
-const tabs = {
+const indexToTabs = {
   0: 'additional',
   1: 'all',
 };
 
-const ImagePackagesTab = ({ imageVersion }) => {
-  const [packageData, setPackageData] = useState({});
-  const [toggleTable, setToggleTable] = useState(1);
+const tabsToIndex = {
+  additional: 0,
+  all: 1,
+};
 
+const ImagePackagesTab = ({ imageVersion }) => {
   const location = useLocation();
   const history = useHistory();
+  const splitUrl = location.pathname.split('/');
+  const defaultToggle = splitUrl.length === 6 ? tabsToIndex[splitUrl[5]] : 1;
+
+  const [packageData, setPackageData] = useState({});
+  const [toggleTable, setToggleTable] = useState(defaultToggle);
 
   useEffect(() => {
     setPackageData(imageVersion);
   }, [imageVersion]);
 
   useEffect(() => {
-    const splitUrl = location.pathname.split('/');
     const currentTab = splitUrl[4].toLowerCase();
 
     if (currentTab === 'packages') {
       if (splitUrl.length === 6) {
-        splitUrl[5] = tabs[toggleTable];
+        splitUrl[5] = indexToTabs[toggleTable];
       } else {
-        splitUrl.push(tabs[toggleTable]);
+        splitUrl.push(indexToTabs[toggleTable]);
       }
     }
 


### PR DESCRIPTION
# Description

Fixed bug to where now using a url like so (manage-images/2665/4481/packages/additional) with the text 'additional' appended at the end would direct it to the proper additional toggle  

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted