### PR TITLE
Add DDF common package to deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@babel/runtime": "7.15.4",
+        "@data-driven-forms/common": "^3.16.0",
         "@data-driven-forms/pf4-component-mapper": "^3.16.0",
         "@data-driven-forms/react-form-renderer": "^3.16.0",
         "@patternfly/patternfly": "4.132.2",
@@ -2998,9 +2999,9 @@
       "dev": true
     },
     "node_modules/@data-driven-forms/common": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.12.1.tgz",
-      "integrity": "sha512-GZS56L4lNlZq+CQumF9iI3LK6OfmvbbwzwlABtOcdcNd9XMuKgSHSeZ4IlhTzANSQ19XPtdbfniV4i1eRKaMkw==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.16.0.tgz",
+      "integrity": "sha512-M3kwwaAa3dANx3ZlLY7NVFPBUyKSpzIPhHyXniAe/2TFqnwMUNE8iPzoQkB94B170qRYApca0NBufnK8XznhpQ==",
       "dependencies": {
         "clsx": "^1.0.4",
         "lodash": "^4.17.15",
@@ -3008,8 +3009,8 @@
         "react-select": "^3.0.8"
       },
       "peerDependencies": {
-        "react": ">=16.13.1",
-        "react-dom": ">=16.13.1"
+        "react": "^16.13.1 || ^17.0.2",
+        "react-dom": "^16.13.1 || ^17.0.2"
       }
     },
     "node_modules/@data-driven-forms/pf4-component-mapper": {
@@ -4633,6 +4634,7 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
       "integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
+      "deprecated": "Use the original unforked package instead: postcss-markdown",
       "dev": true,
       "dependencies": {
         "remark": "^13.0.0",
@@ -7198,7 +7200,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
       "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
@@ -23295,9 +23297,9 @@
       "dev": true
     },
     "@data-driven-forms/common": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.12.1.tgz",
-      "integrity": "sha512-GZS56L4lNlZq+CQumF9iI3LK6OfmvbbwzwlABtOcdcNd9XMuKgSHSeZ4IlhTzANSQ19XPtdbfniV4i1eRKaMkw==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.16.0.tgz",
+      "integrity": "sha512-M3kwwaAa3dANx3ZlLY7NVFPBUyKSpzIPhHyXniAe/2TFqnwMUNE8iPzoQkB94B170qRYApca0NBufnK8XznhpQ==",
       "requires": {
         "clsx": "^1.0.4",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "7.15.4",
+    "@data-driven-forms/common": "^3.16.0",
     "@data-driven-forms/pf4-component-mapper": "^3.16.0",
     "@data-driven-forms/react-form-renderer": "^3.16.0",
     "@patternfly/patternfly": "4.132.2",


### PR DESCRIPTION
# Description

Data Driven Forms PF4 selects use Data Driven Forms Common package as an internal dependency and both packages have to use the same version, but NPM used (for whatever reason) older one. To keep them the same all the time, I have added the common package to dependencies so they can be always updated together.

Fixes https://issues.redhat.com/browse/THEEDGE-1441

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

This is just a quick fix from my side and adding a test for this case could take a lot of time for me, please feel free to add it later.

- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted