### PR TITLE
Add link to package total and additional list in image detail page

### DIFF
--- a/src/Routes/ImageManagerDetail/ImageDetailTab.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTab.js
@@ -15,6 +15,8 @@ import {
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import { distributionMapper } from './constants';
 import PropTypes from 'prop-types';
+import { routes as paths } from '../../../package.json';
+import { Link } from 'react-router-dom';
 
 const ImageDetailTab = ({ imageData, imageVersion }) => {
   const [data, setData] = useState({});
@@ -46,10 +48,29 @@ const ImageDetailTab = ({ imageData, imageVersion }) => {
     Username: () => data?.image?.Installer?.Username,
     'SSH Key': () => data?.image?.Installer?.SshKey,
   };
+  const renderAdditionalPackageLink = () => {
+    return (
+      <Link
+        to={`${paths['manage-images']}/${data?.image?.ImageSetID}/${data?.image?.ID}/packages/additional`}
+      >
+        {data?.additional_packages}
+      </Link>
+    );
+  };
+
+  const renderTotalPackageLink = () => {
+    return (
+      <Link
+        to={`${paths['manage-images']}/${data?.image?.ImageSetID}/${data?.image?.ID}/packages/all`}
+      >
+        {data?.packages}
+      </Link>
+    );
+  };
 
   const packageMapper = {
-    'Total Additional Packages': () => data?.additional_packages,
-    'Total Packages': () => data?.packages,
+    'Total Additional Packages': renderAdditionalPackageLink,
+    'Total Packages': renderTotalPackageLink,
   };
 
   const packageDiffMapper = {


### PR DESCRIPTION
Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

# Description

Add links to show total and additional packages in image detail page 

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted