### PR TITLE
added empty state when packages are still being added to image

### DIFF
--- a/src/Routes/ImageManagerDetail/ImagePackagesTab.js
+++ b/src/Routes/ImageManagerDetail/ImagePackagesTab.js
@@ -5,6 +5,7 @@ import GeneralTable from '../../components/general-table/GeneralTable';
 import PropTypes from 'prop-types';
 import { cellWidth } from '@patternfly/react-table';
 import { useHistory, useLocation } from 'react-router-dom';
+import Empty from '../../components/Empty';
 
 const defaultFilters = [{ label: 'Name', type: 'text' }];
 
@@ -113,7 +114,7 @@ const ImagePackagesTab = ({ imageVersion }) => {
     }
   };
 
-  return (
+  return imageVersion?.image?.Commit?.Status === 'SUCCESS' ? (
     <GeneralTable
       apiFilterSort={false}
       filters={defaultFilters}
@@ -146,6 +147,14 @@ const ImagePackagesTab = ({ imageVersion }) => {
       toggleAction={handleToggleTable}
       toggleState={toggleTable}
       emptyStateMessage="No packages to display"
+    />
+  ) : (
+    <Empty
+      bgColor="white"
+      title="Package data unavailable"
+      body="Image is currently being built. Once finished packages will be displayed."
+      primaryAction={null}
+      secondaryActions={[]}
     />
   );
 };

--- a/src/components/Empty.js
+++ b/src/components/Empty.js
@@ -26,7 +26,7 @@ const Empty = ({
   secondaryActions,
 }) => (
   <EmptyState style={{ backgroundColor: bgColor || '' }}>
-    <EmptyStateIcon icon={emptyStateIconMapper[icon]} />
+    {icon && <EmptyStateIcon icon={emptyStateIconMapper[icon]} />}
     <Title headingLevel="h4" size="lg">
       {title}
     </Title>


### PR DESCRIPTION
# Description

Changed default state on packages tab for image sets when the image is still being built. 

Fixes # (issue)
https://issues.redhat.com/browse/THEEDGE-1451

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted