### PR TITLE
change image-set param from updated_at to created_at

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -358,7 +358,7 @@ export const fetchEdgeImageSets = (
   q = {
     limit: 100,
     offset: 0,
-    sort_by: '-updated_at',
+    sort_by: '-created_at',
   }
 ) => {
   const query = getTableParams(q);
@@ -409,7 +409,7 @@ export const getImageSet = ({
   q = {
     limit: 100,
     offset: 0,
-    sort_by: '-updated_at',
+    sort_by: '-created_at',
   },
 }) => {
   const query = getTableParams(q);


### PR DESCRIPTION
# Description

change param for image-sets api call from updated_at to created_at to fix issue with wrong status in image-sets details header

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted