### PR TITLE
Fixed extra forward slash in image-set details url

### DIFF
--- a/src/Routes/ImageManagerDetail/ImageDetailTabs.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTabs.js
@@ -24,7 +24,7 @@ const ImageDetailTabs = ({
   const history = useHistory();
   const [activeTabKey, setActiveTabkey] = useState(tabs.details);
 
-  const paramIndex = imageVersion ? 5 : 4;
+  const paramIndex = imageVersion ? 4 : 3;
   const splitUrl = location.pathname.split('/');
 
   const handleTabClick = (_event, tabIndex) => {
@@ -43,7 +43,7 @@ const ImageDetailTabs = ({
   };
 
   useEffect(() => {
-    tabs[splitUrl[4]] !== activeTabKey && setActiveTabkey(tabs[splitUrl[5]]);
+    tabs[splitUrl[3]] !== activeTabKey && setActiveTabkey(tabs[splitUrl[4]]);
   }, [splitUrl]);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Fixed extra forward slash in url of image-sets when clicking on tabs, index was off by one.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted