### PR TITLE
Link CVEs to Customer portal instead of Vulnerability app

### DIFF
--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -32,12 +32,12 @@ const VulnerabilityTab = ({ imageId }) => {
         appName="vulnerability"
         module="./SystemDetail"
         getRegistry={getRegistry}
-        customItnlProvider
+        customIntlProvider
         entity={{ id: params.inventoryId }}
         canSelect={false}
         canEditStatus={false}
         canManageColumns={false}
-        linkAdvisoriesToCustomerPortal
+        linkToCustomerPortal
         defaultColumns={[
           'synopsis',
           'public_date',


### PR DESCRIPTION
# Description

Changed two props from the Vulnerability Tab:
- `customIntlProvider` fixes a typo in word `Intl` and has no effect
- replace `linkAdvisoriesToCustomerPortal` prop with `linkToCustomerPortal` as it's been renamed in the Vulnerability app, so now Advisories and CVEs links link to Customer portal instead of Insights Patchman/Vulnerability apps.

cc: @matoval 

Fixes last item in [VULN-2047](https://issues.redhat.com/browse/VULN-2047).

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted