### PR TITLE
fix spacing between name and updated time

### DIFF
--- a/src/Routes/ImageManagerDetail/DetailsHeader.js
+++ b/src/Routes/ImageManagerDetail/DetailsHeader.js
@@ -20,6 +20,7 @@ import {
 import StatusLabel from './StatusLabel';
 import { routes as paths } from '../../../package.json';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 const dropdownItems = (data, imageVersion, openUpdateWizard) => {
   const imageData = imageVersion ? imageVersion : data?.images?.[0];
@@ -90,7 +91,10 @@ const DetailsHead = ({ imageData, imageVersion, openUpdateWizard }) => {
         <Split>
           <SplitItem>
             <TextList component="dl">
-              <TextListItem component="h1" className="grid-align-center">
+              <TextListItem
+                component="h1"
+                className="grid-align-center pf-u-mb-0"
+              >
                 {data?.image_set?.Name || <Skeleton width="150px" />}
               </TextListItem>
               <TextListItem component="dd">
@@ -99,6 +103,16 @@ const DetailsHead = ({ imageData, imageVersion, openUpdateWizard }) => {
                 ) : (
                   <Skeleton width="100px" />
                 )}
+              </TextListItem>
+              <TextListItem component="p">
+                {`Last updated `}
+                <DateFormat
+                  date={
+                    imageVersion
+                      ? imageVersion?.image?.UpdatedAt
+                      : data?.images?.[0].image?.UpdatedAt
+                  }
+                />
               </TextListItem>
             </TextList>
           </SplitItem>

--- a/src/Routes/ImageManagerDetail/ImageDetail.js
+++ b/src/Routes/ImageManagerDetail/ImageDetail.js
@@ -6,13 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { PageHeader } from '@redhat-cloud-services/frontend-components/PageHeader';
-import {
-  Stack,
-  StackItem,
-  Text,
-  Spinner,
-  Bullseye,
-} from '@patternfly/react-core';
+import { Stack, StackItem, Spinner, Bullseye } from '@patternfly/react-core';
 import { useDispatch } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { loadImageSetDetail } from '../../store/actions';
@@ -22,7 +16,6 @@ import { useSelector, shallowEqual } from 'react-redux';
 import DetailsHead from './DetailsHeader';
 import ImageDetailTabs from './ImageDetailTabs';
 import UpdateImageWizard from '../ImageManager/UpdateImageWizard';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 const ImageDetail = () => {
   const { imageId, imageVersionId } = useParams();
@@ -90,20 +83,6 @@ const ImageDetail = () => {
             />
           </StackItem>
         </Stack>
-        <StackItem>
-          {imageSetData?.data?.Data && (
-            <Text>
-              {`Last updated `}
-              <DateFormat
-                date={
-                  imageVersion
-                    ? imageVersion?.image?.UpdatedAt
-                    : imageSetData?.data?.Data?.images?.[0].image?.UpdatedAt
-                }
-              />
-            </Text>
-          )}
-        </StackItem>
       </PageHeader>
       <ImageDetailTabs
         imageData={imageSetData}


### PR DESCRIPTION
# Description

Fix spacing between name and updated time in image-set details header

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted