### PR TITLE
Require 2 approvals to auto merge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - base=master
-      - "#approved-reviews-by>=1"
+      - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - check-success=Travis CI - Pull Request 
       - label!=work in progress


### PR DESCRIPTION
# Description

Change Mergify config to require two approvals before auto merge

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted