### PR TITLE
Don't allow alerts if image is unavailable

### DIFF
--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -9,11 +9,17 @@ import { InProgressIcon } from '@patternfly/react-icons';
 import UpdateImageModal from './UpdateImageModal';
 import { getImageSet } from '../../api/index';
 
-const getActiveAlert = (CVEs, systemProfile, newImageStatus, prevState) => {
+const getActiveAlert = (
+  CVEs,
+  systemProfile,
+  newImageStatus,
+  imageId,
+  prevState
+) => {
   if (CVEs?.isLoading || CVEs?.meta?.filter || !systemProfile?.system_profile) {
     return prevState;
   }
-  if (!CVEs?.data?.length > 0) {
+  if (!CVEs?.data?.length > 0 || !imageId) {
     return 'noAlert';
   }
   if (
@@ -78,7 +84,7 @@ const VulnerabilityTab = ({
       }));
 
     setActiveAlert((prevState) =>
-      getActiveAlert(CVEs, systemProfile, newImageStatus, prevState)
+      getActiveAlert(CVEs, systemProfile, newImageStatus, imageId, prevState)
     );
   }, [CVEs, systemProfile, newImageStatus]);
 


### PR DESCRIPTION
# Description

Don't show alerts if image is unavailable

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted