### PR TITLE
Time fixes

### DIFF
--- a/src/Routes/Devices/UpdateDeviceModal.js
+++ b/src/Routes/Devices/UpdateDeviceModal.js
@@ -97,7 +97,7 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
             Created
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            <DateFormat date={imageData?.Image.CreatedAt} />
+            <DateFormat date={imageData?.Image.CreatedAt.Time} />
           </TextListItem>
           <TextListItem component={TextListItemVariants.dt}>
             Release

--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -82,7 +82,7 @@ const createRows = (data) => {
       },
       image_set?.Images[0].Version, // remove when image_set.Version is accurate
       {
-        title: <DateFormat date={image_set?.UpdatedAt} />,
+        title: <DateFormat date={image_set?.UpdatedAt.Time} />,
       },
       {
         title: (

--- a/src/Routes/ImageManager/ImageTable.js
+++ b/src/Routes/ImageManager/ImageTable.js
@@ -63,7 +63,7 @@ const createRows = (data) => {
         title: imageTypeMapper[image?.ImageType],
       },
       {
-        title: <DateFormat date={image?.CreatedAt} />,
+        title: <DateFormat date={image?.CreatedAt.Time} />,
       },
       {
         title: <StatusLabel status={image?.Status} />,

--- a/src/Routes/ImageManagerDetail/DetailsHeader.js
+++ b/src/Routes/ImageManagerDetail/DetailsHeader.js
@@ -104,15 +104,15 @@ const DetailsHead = ({ imageData, imageVersion, openUpdateWizard }) => {
                   <Skeleton width="100px" />
                 )}
               </TextListItem>
-              {imageVersion?.image?.UpdatedAt ||
-              data?.images?.[0].image?.UpdatedAt ? (
+              {imageVersion?.image?.UpdatedAt.Time ||
+              data?.images?.[0].image?.UpdatedAt.Time ? (
                 <TextListItem component="p">
                   {`Last updated `}
                   <DateFormat
                     date={
                       imageVersion
-                        ? imageVersion?.image?.UpdatedAt
-                        : data?.images?.[0].image?.UpdatedAt
+                        ? imageVersion?.image?.UpdatedAt.Time
+                        : data?.images?.[0].image?.UpdatedAt.Time
                     }
                   />
                 </TextListItem>

--- a/src/Routes/ImageManagerDetail/DetailsHeader.test.js
+++ b/src/Routes/ImageManagerDetail/DetailsHeader.test.js
@@ -19,7 +19,7 @@ describe('DetailsHeader', () => {
                 Version: 1,
                 ImageType: 'rhel-edge-installer',
                 CreatedAt: { Time: '2022-01-24T18:27:24.331554Z', Valid: true },
-                UpdatedAt: Date.now(),
+                UpdatedAt: { Time: Date.now(), Valid: true },
                 Status: 'BUILDING',
                 Installer: {
                   ImageBuildISOURL: '',

--- a/src/Routes/ImageManagerDetail/DetailsHeader.test.js
+++ b/src/Routes/ImageManagerDetail/DetailsHeader.test.js
@@ -18,7 +18,7 @@ describe('DetailsHeader', () => {
                 ID: 100,
                 Version: 1,
                 ImageType: 'rhel-edge-installer',
-                CreatedAt: '2022-01-24T18:27:24.331554Z',
+                CreatedAt: { Time: '2022-01-24T18:27:24.331554Z', Valid: true },
                 UpdatedAt: Date.now(),
                 Status: 'BUILDING',
                 Installer: {
@@ -31,7 +31,7 @@ describe('DetailsHeader', () => {
                 ID: 200,
                 Version: 2,
                 ImageType: 'rhel-edge-installer',
-                CreatedAt: '2022-01-24T18:27:24.331554Z',
+                CreatedAt: { Time: '2022-01-24T18:27:24.331554Z', Valid: true },
                 Status: 'SUCCESS',
                 Installer: {
                   ImageBuildISOURL: 'test.com',

--- a/src/Routes/ImageManagerDetail/ImageDetailTab.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTab.js
@@ -30,7 +30,9 @@ const ImageDetailTab = ({ imageData, imageVersion }) => {
   const createSkeleton = (rows) =>
     [...Array(rows * 2)].map((key) => <Skeleton width="180px" key={key} />);
 
-  const dateFormat = () => <DateFormat date={data?.image?.['CreatedAt']['Time']} />;
+  const dateFormat = () => (
+    <DateFormat date={data?.image?.['CreatedAt']['Time']} />
+  );
 
   const detailsMapper = {
     Version: 'Version',

--- a/src/Routes/ImageManagerDetail/ImageDetailTab.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTab.js
@@ -30,7 +30,7 @@ const ImageDetailTab = ({ imageData, imageVersion }) => {
   const createSkeleton = (rows) =>
     [...Array(rows * 2)].map((key) => <Skeleton width="180px" key={key} />);
 
-  const dateFormat = () => <DateFormat date={data?.image?.['CreatedAt']} />;
+  const dateFormat = () => <DateFormat date={data?.image?.['CreatedAt']['Time']} />;
 
   const detailsMapper = {
     Version: 'Version',

--- a/src/Routes/ImageManagerDetail/ImageVersionsTab.js
+++ b/src/Routes/ImageManagerDetail/ImageVersionsTab.js
@@ -57,7 +57,7 @@ const createRows = (data, imageSetId) => {
     noApiSortFilter: [
       image?.Version,
       imageTypeMapper[image?.ImageType],
-      image?.CreatedAt,
+      image?.CreatedAt.Time,
       image?.Status,
     ],
     cells: [
@@ -74,7 +74,7 @@ const createRows = (data, imageSetId) => {
         title: imageTypeMapper[image?.ImageType],
       },
       {
-        title: <DateFormat date={image?.CreatedAt} />,
+        title: <DateFormat date={image?.CreatedAt.Time} />,
       },
       {
         title: <StatusLabel status={image?.Status} />,

--- a/src/Routes/ImageManagerDetail/ImageVersionsTab.test.js
+++ b/src/Routes/ImageManagerDetail/ImageVersionsTab.test.js
@@ -18,7 +18,7 @@ describe('ImageVersionsTab', () => {
                 ID: 100,
                 Version: 1,
                 ImageType: 'rhel-edge-installer',
-                CreatedAt: '2022-01-24T18:27:24.331554Z',
+                CreatedAt: { Time: '2022-01-24T18:27:24.331554Z', Valid: true },
                 Status: 'BUILDING',
                 Installer: {
                   ImageBuildISOURL: '',
@@ -30,7 +30,7 @@ describe('ImageVersionsTab', () => {
                 ID: 200,
                 Version: 2,
                 ImageType: 'rhel-edge-installer',
-                CreatedAt: '2022-01-24T18:27:24.331554Z',
+                CreatedAt: { Time: '2022-01-24T18:27:24.331554Z', Valid: true },
                 Status: 'SUCCESS',
                 Installer: {
                   ImageBuildISOURL: 'test.com',


### PR DESCRIPTION
# Description

Backend changed the CreatedAt/UpdatedAt fields from `time.Time` to `sql.NullTime`.

This caused an `Invalid date` since now each field is now a struct with 2 fields, e.g: 
```
"CreatedAt":{"Time":"2021-12-22T19:20:27.53471Z","Valid":true}
```

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted