### PR TITLE
Moved validator function to ImageCreator to fix errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ node_modules
 # production
 dist
 
+#cypress
+cypress/videos
+cypress/fixtures
+cypress/screenshots
 cypress/config
 
 npm-debug.log*

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -2,23 +2,11 @@ import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import { Flex, FlexItem, Text } from '@patternfly/react-core';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-import { checkImageName } from '../../../api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { nameValidator } from '../../../constants';
 
 const helperText =
   'Can only contain letters, numbers, spaces, hyphens( - ), and underscores( _ ).';
-
-const asyncImageNameValidation = (value) =>
-  checkImageName(value)
-    .then((result) => {
-      if (result.ImageExists) {
-        throw new Error('Name already exists');
-      }
-    })
-    .catch(({ message }) => {
-      throw message;
-    });
 
 const CharacterCount = () => {
   const { getState } = useFormApi();
@@ -47,7 +35,7 @@ export default {
       placeholder: 'Image name',
       helperText: helperText,
       validate: [
-        asyncImageNameValidation,
+        { type: 'asyncImageNameValidation' },
         { type: validatorTypes.REQUIRED },
         nameValidator,
         { type: validatorTypes.MAX_LENGTH, threshold: 50 },

--- a/src/components/ImageCreator.js
+++ b/src/components/ImageCreator.js
@@ -14,6 +14,7 @@ import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComp
 import { registrationCredsValidator } from './form/RegistrationCreds';
 import { reservedUsernameValidator } from './form/validators';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
+import { checkImageName } from '../api';
 
 /**
  * Use this instead of CreateImageWizard once this PR is merged https://github.com/RedHatInsights/image-builder-frontend/pull/230
@@ -28,6 +29,17 @@ export const AsyncCreateImageWizard = (props) => (
     {...props}
   />
 );
+
+const asyncImageNameValidation = () => (value) =>
+  checkImageName(value)
+    .then((result) => {
+      if (result.ImageExists) {
+        throw new Error('Name already exists');
+      }
+    })
+    .catch(({ message }) => {
+      throw message;
+    });
 
 const CreateImageWizard = ({
   schema,
@@ -68,6 +80,7 @@ const CreateImageWizard = ({
       }}
       validatorMapper={{
         ...validatorTypes,
+        asyncImageNameValidation,
         registrationCredsValidator,
         reservedUsernameValidator,
       }}


### PR DESCRIPTION
# Description

Moved validator function to ImageCreator to fix errors in console when clicking next after validation image name.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted