### PR TITLE
Add interface for custom repo step on image create wizard

### DIFF
--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -5,6 +5,7 @@ import {
   registration,
   review,
   packages,
+  repositories,
   imageSetDetails,
   imageOutput,
 } from './steps';
@@ -116,6 +117,7 @@ const CreateImage = ({ navigateBack }) => {
               imageSetDetails,
               imageOutput,
               registration,
+              repositories,
               packages,
               review,
             ],

--- a/src/Routes/ImageManager/steps/index.js
+++ b/src/Routes/ImageManager/steps/index.js
@@ -4,3 +4,4 @@ export { default as imageOutput } from './imageOutput';
 export { default as imageSetDetails } from './imageSetDetails';
 export { default as updateDetails } from './updateDetails';
 export { default as registration } from './registration';
+export { default as repositories } from './repositories';

--- a/src/Routes/ImageManager/steps/packages.js
+++ b/src/Routes/ImageManager/steps/packages.js
@@ -21,6 +21,7 @@ export default {
   title: 'Additional packages',
   name: 'packages',
   nextStep: 'review',
+  substepOf: 'Add content',
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,

--- a/src/Routes/ImageManager/steps/registration.js
+++ b/src/Routes/ImageManager/steps/registration.js
@@ -6,7 +6,7 @@ import validatorTypes from '@data-driven-forms/react-form-renderer/validator-typ
 export default {
   title: 'Device registration',
   name: 'registration',
-  nextStep: 'packages',
+  nextStep: 'repositories',
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,

--- a/src/Routes/ImageManager/steps/repositories.js
+++ b/src/Routes/ImageManager/steps/repositories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import { Text } from '@patternfly/react-core';
+
+export default {
+  title: 'Custom repositories',
+  name: 'repositories',
+  nextStep: 'packages',
+  substepOf: 'Add content',
+  fields: [
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'description',
+      label: <Text>Coming soon to our platform</Text>,
+    },
+  ],
+};

--- a/src/Routes/ImageManager/steps/repositories.js
+++ b/src/Routes/ImageManager/steps/repositories.js
@@ -1,6 +1,14 @@
 import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { Text } from '@patternfly/react-core';
+import RepositoryTable from '../../Repositories/RepositoryTable';
+
+const mockRepositories = [
+  {
+    id: 1,
+    name: 'AWS repository',
+    baseURL: 'rh.aws.com',
+  },
+];
 
 export default {
   title: 'Custom repositories',
@@ -10,8 +18,8 @@ export default {
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
-      name: 'description',
-      label: <Text>Coming soon to our platform</Text>,
+      name: 'repository-table',
+      label: <RepositoryTable data={mockRepositories} mode="selection" />,
     },
   ],
 };

--- a/src/Routes/Repositories/RepositoryTable.js
+++ b/src/Routes/Repositories/RepositoryTable.js
@@ -5,32 +5,35 @@ import { Text, TextVariants } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
 const filters = [{ label: 'Name', type: 'text' }];
+const modeSelection = 'selection';
 
-const RepositoryTable = ({ data, openModal }) => {
+const RepositoryTable = ({ data, openModal, mode }) => {
   const actionResolver = (rowData) => {
     const { id, repoName, repoBaseURL } = rowData;
-    return [
-      {
-        title: 'Edit',
-        onClick: () =>
-          openModal({
-            type: 'edit',
-            id: id,
-            name: repoName,
-            baseURL: repoBaseURL,
-          }),
-      },
-      {
-        title: 'Remove',
-        onClick: () =>
-          openModal({
-            type: 'remove',
-            id: id,
-            name: repoName,
-            baseURL: repoBaseURL,
-          }),
-      },
-    ];
+    return mode === modeSelection
+      ? []
+      : [
+          {
+            title: 'Edit',
+            onClick: () =>
+              openModal({
+                type: 'edit',
+                id: id,
+                name: repoName,
+                baseURL: repoBaseURL,
+              }),
+          },
+          {
+            title: 'Remove',
+            onClick: () =>
+              openModal({
+                type: 'remove',
+                id: id,
+                name: repoName,
+                baseURL: repoBaseURL,
+              }),
+          },
+        ];
   };
 
   const buildRows = data.map(({ id, name, baseURL }) => {
@@ -76,18 +79,23 @@ const RepositoryTable = ({ data, openModal }) => {
       actionResolver={actionResolver}
       areActionsDisabled={() => false}
       defaultSort={{ index: 0, direction: 'desc' }}
-      toolbarButtons={[
-        {
-          title: 'Add repository',
-          click: () => openModal({ type: 'add' }),
-        },
-      ]}
+      toolbarButtons={
+        mode === modeSelection
+          ? []
+          : [
+              {
+                title: 'Add repository',
+                click: () => openModal({ type: 'add' }),
+              },
+            ]
+      }
     />
   );
 };
 RepositoryTable.propTypes = {
   data: PropTypes.array,
   openModal: PropTypes.func,
+  mode: PropTypes.string,
 };
 
 export default RepositoryTable;


### PR DESCRIPTION
Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

# Description

Add new step for image create wizard contains the table and modify the repository table component to support a selection mode to be used on image create.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted