### PR TITLE
add selected mode on respository and solve issue on change output checkbox

### DIFF
--- a/src/Routes/ImageManager/steps/imageOutput.js
+++ b/src/Routes/ImageManager/steps/imageOutput.js
@@ -14,7 +14,7 @@ export default {
   nextStep: ({ values }) =>
     values?.imageType?.includes('rhel-edge-installer') || !values.imageType
       ? 'registration'
-      : 'packages',
+      : 'repositories',
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,

--- a/src/Routes/ImageManager/steps/repositories.js
+++ b/src/Routes/ImageManager/steps/repositories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import RepositoryTable from '../../Repositories/RepositoryTable';
+import { Text } from '@patternfly/react-core';
 
 const mockRepositories = [
   {
@@ -16,6 +17,16 @@ export default {
   nextStep: 'packages',
   substepOf: 'Add content',
   fields: [
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'description',
+      label: (
+        <Text>
+          Choose from linked custom repositories from which to search and add
+          packages to this image.
+        </Text>
+      ),
+    },
     {
       component: componentTypes.PLAIN_TEXT,
       name: 'repository-table',

--- a/src/Routes/Repositories/RepositoryTable.js
+++ b/src/Routes/Repositories/RepositoryTable.js
@@ -89,6 +89,7 @@ const RepositoryTable = ({ data, openModal, mode }) => {
               },
             ]
       }
+      hasCheckbox={mode === modeSelection}
     />
   );
 };


### PR DESCRIPTION
Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

# Description

- Bug fix: Correct menu order for create image wizard when output checkbox state on output screen (details: https://issues.redhat.com/browse/THEEDGE-1583)
- Add selected state in custom repositories step in create image wizard. 

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted