### PR TITLE
Add internal data load in custom repositoryTable

### DIFF
--- a/src/Routes/ImageManager/steps/repositories.js
+++ b/src/Routes/ImageManager/steps/repositories.js
@@ -3,14 +3,6 @@ import componentTypes from '@data-driven-forms/react-form-renderer/component-typ
 import { Text } from '@patternfly/react-core';
 import RepositoryTable from '../../Repositories/RepositoryTable';
 
-const mockRepositories = [
-  {
-    id: 1,
-    name: 'AWS repository',
-    baseURL: 'rh.aws.com',
-  },
-];
-
 export default {
   title: 'Custom repositories',
   name: 'repositories',
@@ -30,7 +22,7 @@ export default {
     {
       component: componentTypes.PLAIN_TEXT,
       name: 'repository-table',
-      label: <RepositoryTable data={mockRepositories} mode="selection" />,
+      label: <RepositoryTable mode="selection" />,
     },
   ],
 };

--- a/src/Routes/Repositories/RepositoryTable.js
+++ b/src/Routes/Repositories/RepositoryTable.js
@@ -11,7 +11,7 @@ const modeSelection = 'selection';
 
 const RepositoryTable = ({ data, openModal, mode }) => {
   const [internalData, setInternalData] = useState([]);
-  const [loaded, setLoaded] = useState(false);
+  const [loaded, setLoaded] = useState(data !== undefined);
   const actionResolver = (rowData) => {
     const { id, repoName, repoBaseURL } = rowData;
     return mode === modeSelection

--- a/src/Routes/Repositories/RepositoryTable.js
+++ b/src/Routes/Repositories/RepositoryTable.js
@@ -1,13 +1,17 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import GeneralTable from '../../components/general-table/GeneralTable';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Text, TextVariants } from '@patternfly/react-core';
+import { getCustomRepositories } from '../../api/index';
 import PropTypes from 'prop-types';
+import { Skeleton } from '@patternfly/react-core';
 
 const filters = [{ label: 'Name', type: 'text' }];
 const modeSelection = 'selection';
 
 const RepositoryTable = ({ data, openModal, mode }) => {
+  const [internalData, setInternalData] = useState([]);
+  const [loaded, setLoaded] = useState(false);
   const actionResolver = (rowData) => {
     const { id, repoName, repoBaseURL } = rowData;
     return mode === modeSelection
@@ -36,7 +40,33 @@ const RepositoryTable = ({ data, openModal, mode }) => {
         ];
   };
 
-  const buildRows = data.map(({ id, name, baseURL }) => {
+  const reloadData = async () => {
+    const repos = await getCustomRepositories();
+    setInternalData(
+      repos.data.map((repo) => ({
+        id: repo.ID,
+        name: repo.Name,
+        baseURL: repo.URL,
+        ...repo,
+      }))
+    );
+    setLoaded(true);
+  };
+
+  const getDataSource = () => (data ? data : internalData ? internalData : []);
+
+  const getTableData = () => {
+    return {
+      count: getDataSource().length,
+      data: getDataSource(),
+      isLoading: false,
+      hasError: false,
+    };
+  };
+
+  useEffect(() => reloadData(), []);
+
+  const buildRows = getDataSource().map(({ id, name, baseURL }) => {
     return {
       id: id,
       repoName: name,
@@ -64,16 +94,11 @@ const RepositoryTable = ({ data, openModal, mode }) => {
     };
   });
 
-  return (
+  return loaded ? (
     <GeneralTable
       apiFilterSort={false}
       filters={filters}
-      tableData={{
-        count: data.length,
-        data,
-        isLoading: false,
-        hasError: false,
-      }}
+      tableData={getTableData()}
       columnNames={[{ title: 'Name', type: 'name', sort: true }]}
       rows={buildRows}
       actionResolver={actionResolver}
@@ -91,6 +116,8 @@ const RepositoryTable = ({ data, openModal, mode }) => {
       }
       hasCheckbox={mode === modeSelection}
     />
+  ) : (
+    <Skeleton />
   );
 };
 RepositoryTable.propTypes = {


### PR DESCRIPTION


Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

# Description

Add the capacity to load data internally for repositoryTable to avoid flick UI on CreateImageWizard and UpdateImageWizard, this will not affect current screen, once data received as props is prioritary over internally loaded data

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted