### PR TITLE
updated text for repos empty-state add button

### DIFF
--- a/src/Routes/Repositories/Repositories.js
+++ b/src/Routes/Repositories/Repositories.js
@@ -68,7 +68,7 @@ const Repository = () => {
               title="Add a custom repository"
               body="Add custom repositories to build RHEL for Edge images with additional packages."
               primaryAction={{
-                text: 'Add Repository',
+                text: 'Add repository',
                 click: () => openModal({ type: 'add' }),
               }}
               secondaryActions={


### PR DESCRIPTION

# Description

changed the text of the add button on the repositories empty-state to match all the other buttons (especially the one on the repositories page)
