### PR TITLE
added default props to empty component

### DIFF
--- a/src/components/Empty.js
+++ b/src/components/Empty.js
@@ -81,4 +81,8 @@ Empty.propTypes = {
   secondaryActions: PropTypes.array,
 };
 
+Empty.defaultProps = {
+  secondaryActions: [],
+};
+
 export default Empty;


### PR DESCRIPTION
# Description

Add default props to Empty component to avoid adding an empty array

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted