### PR TITLE
 change api implementation to inventory screen

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -17,11 +17,7 @@ import {
 import { emptyStateNoFliters } from '../../constants';
 
 const getDeviceStatus = (deviceData) =>
-  deviceData?.ImageInfo?.UpdatesAvailable
-    ? 'updateAvailable'
-    : deviceData?.Device?.Booted
-    ? 'running'
-    : 'booting';
+  deviceData?.UpdateAvailable ? 'updateAvailable' : deviceData?.Status;
 
 const DeviceStatus = ({ Device }) => {
   const status = getDeviceStatus(Device);
@@ -108,35 +104,34 @@ const columnNames = [
 const createRows = (devices) =>
   devices?.map((device) => ({
     rowInfo: {
-      deviceID: device?.Device?.ID,
-      id: device?.Device?.UUID,
-      display_name: device?.Device?.DeviceName,
-      updateImageData: device?.ImageInfo?.UpdatesAvailable?.[0],
+      deviceID: device?.DeviceId,
+      id: device?.DeviceUUID,
+      display_name: device?.DeviceName,
+      updateImageData: device?.UpdateAvailable,
       deviceStatus: getDeviceStatus(device),
-      imageSetId: device?.ImageInfo?.Image?.ImageSetID,
-      imageName: device?.ImageInfo?.Image?.Name,
+      imageSetId: device?.ImageSetID,
+      imageName: device?.ImageName,
     },
     noApiSortFilter: [
-      device?.Device?.DeviceName || '',
-      device?.ImageInfo?.Image?.Name || '',
+      device?.DeviceName || '',
       '',
-      device?.Device?.LastSeen || '',
+      device?.LastSeen || '',
       getDeviceStatus(device),
     ],
     cells: [
       {
         title: (
-          <Link to={`${paths['inventory']}/${device?.Device?.UUID}`}>
-            {device?.Device?.DeviceName}
+          <Link to={`${paths['inventory']}/${device?.DeviceUUID}`}>
+            {device?.DeviceName}
           </Link>
         ),
       },
       {
-        title: device?.ImageInfo?.Image?.Name ? (
+        title: device?.ImageName ? (
           <Link
-            to={`${paths['manage-images']}/${device?.ImageInfo?.Image?.ImageSetID}/versions/${device?.ImageInfo?.Image?.ID}/details`}
+            to={`${paths['manage-images']}/${device?.ImageSetID}/versions/${device?.ImageID}/details`}
           >
-            {device?.ImageInfo?.Image?.Name}
+            {device?.ImageName}
           </Link>
         ) : (
           'unavailable'
@@ -146,7 +141,7 @@ const createRows = (devices) =>
         title: '-',
       },
       {
-        title: <DateFormat date={device?.Device?.LastSeen} />,
+        title: <DateFormat date={device?.LastSeen} />,
       },
       {
         title: <DeviceStatus Device={device} />,
@@ -176,7 +171,7 @@ const DeviceTable = ({
   const actionResolver = (rowData) => {
     const actions = [];
     if (isLoading) return actions;
-    if (!rowData.rowInfo.id) return actions;
+    if (!rowData.rowInfo?.id) return actions;
 
     if (!areActionsDisabled(rowData)) {
       actions.push({
@@ -244,7 +239,7 @@ const DeviceTable = ({
             hasError: hasError,
           }}
           columnNames={columnNames}
-          rows={createRows(data || [])}
+          rows={createRows(data) || []}
           actionResolver={actionResolver}
           areActionsDisabled={canBeRemoved ? false : areActionsDisabled}
           defaultSort={{ index: 3, direction: 'desc' }}

--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -31,13 +31,17 @@ const Inventory = () => {
         <PageHeaderTitle title="Systems" />
       </PageHeader>
       <Main className="edge-devices">
-        <DeviceTable
-          data={data?.data}
-          count={data?.count}
-          isLoading={isLoading}
-          hasError={hasError}
-          setUpdateModal={setUpdateModal}
-        />
+        {data ? (
+          <DeviceTable
+            data={data?.data?.devices}
+            count={data?.count}
+            isLoading={isLoading}
+            hasError={hasError}
+            setUpdateModal={setUpdateModal}
+          />
+        ) : (
+          <Fragment />
+        )}
       </Main>
       {updateModal.isOpen && (
         <Suspense

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -443,7 +443,7 @@ export const removeCustomRepository = (id) =>
   instance.delete(`${EDGE_API}/thirdpartyrepo/${id}`);
 
 export const getInventory = async () => {
-  return await instance.get(`${EDGE_API}/devices`);
+  return await instance.get(`${EDGE_API}/devices/devicesview`);
 };
 
 export const createGroup = (payload) => {


### PR DESCRIPTION
Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

# Description

We're moving from previous get /device to get /devicesview to return data to inventory screen. This PR is current incomplete due dependencies in backend, so don't need merge at this moment

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted