### PR TITLE
Fix wizard enter, split by space instead of comma

### DIFF
--- a/src/Routes/ImageManager/steps/customPackage.js
+++ b/src/Routes/ImageManager/steps/customPackage.js
@@ -60,14 +60,12 @@ export default {
       label: <CustomPackageLabel />,
     },
     {
-      component: componentTypes.TEXTAREA,
+      component: 'custom-package-text-area',
       style: {
         paddingRight: '32px',
         height: '25vh',
       },
       name: 'custom-packages',
-      placeholder:
-        'Enter or paste packages from linked repositories, one entry per line.\nExamplePackage\nexample-package\nexamplapackage',
       label: <b> Packages </b>,
       initialValue: [],
       clearedValue: [],

--- a/src/components/form/CustomPackageTextArea.js
+++ b/src/components/form/CustomPackageTextArea.js
@@ -8,11 +8,11 @@ const CustomPackageTextArea = ({ ...props }) => {
   const { input } = useFieldApi(props);
   const wizardState = getState()?.values?.[input.name];
   const [value, setValue] = useState(
-    wizardState?.map((repo) => repo.name).join(',\n')
+    wizardState?.map((repo) => repo.name).join('\n')
   );
 
   useEffect(() => {
-    const customRepoArray = value.split(',').reduce((acc, repo) => {
+    const customRepoArray = value.split(' ').reduce((acc, repo) => {
       const onlyText = repo.replace(/[/ /\n\r\s\t]+/g, '');
       if (onlyText !== '' && onlyText !== '\n') {
         return (acc = [...acc, { name: `${onlyText}` }]);


### PR DESCRIPTION
# Description

Fix wizard enter, split by space instead of comma

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted