### PR TITLE
prevent auth modal flash until data comes back t/f

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,12 +6,13 @@ import { notificationsReducer } from '@redhat-cloud-services/frontend-components
 import { NotificationPortal } from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import './App.scss';
 import AuthModal from './components/AuthModal';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
 const App = (props) => {
   const { getRegistry } = useContext(RegistryContext);
   const [isLogged, setIsLogged] = useState(false);
   const history = useHistory();
-  const [isAuth, setIsAuth] = useState(false);
+  const [isAuth, setIsAuth] = useState(null);
   useEffect(() => {
     insights.chrome.init();
     // TODO change this to your appname
@@ -42,7 +43,15 @@ const App = (props) => {
   return (
     <Fragment>
       <NotificationPortal />
-      {isAuth && isLogged ? <Routes childProps={props} /> : <AuthModal />}
+      {isAuth && isLogged ? (
+        <Routes childProps={props} />
+      ) : isAuth === null ? (
+        <Bullseye>
+          <Spinner size="xl" />
+        </Bullseye>
+      ) : (
+        <AuthModal />
+      )}
     </Fragment>
   );
 };

--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -8,7 +8,7 @@ const AuthModal = () => {
       style={{ padding: '15px' }}
       isOpen={true}
       variant="small"
-      onClose={() => (window.location.href = 'https://www.redhat.com/en')}
+      onClose={() => (window.location.href = 'https://console.redhat.com/')}
       aria-label="auth-modal"
       header={
         <h2 className="pf-u-pr-xl pf-u-pl-xl pf-u-font-size-2xl pf-u-text-align-center pf-u-font-weight-bold">
@@ -49,7 +49,7 @@ const AuthModal = () => {
             component="a"
             key="not-now"
             variant="link"
-            href="https://www.redhat.com/en"
+            href="https://console.redhat.com/"
           >
             Not now
           </Button>


### PR DESCRIPTION
# Description
Prevent auth modal flash while entitlement data loads should show spinner

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted