### PR TITLE
changed table headers to sentence case

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -100,7 +100,7 @@ const columnNames = [
     columnTransforms: [cellWidth(15)],
   },
   {
-    title: 'Last Seen',
+    title: 'Last seen',
     type: 'last_seen',
     sort: true,
     columnTransforms: [cellWidth(15)],

--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -53,13 +53,13 @@ const columnNames = [
     columnTransforms: [cellWidth(35)],
   },
   {
-    title: 'Current Version',
+    title: 'Current version',
     type: 'version',
     sort: false,
     columnTransforms: [cellWidth(15)],
   },
   {
-    title: 'Last Updated',
+    title: 'Last updated',
     type: 'updated_at',
     sort: true,
     columnTransforms: [cellWidth(25)],


### PR DESCRIPTION
# Description

in order to be consistent with the other services/PF guidelines, sentence case should be used in the headers of the tables 



What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
