### PR TITLE
Bug fix 2084 - Pagination Index reset after external update

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -225,6 +225,7 @@ const DeviceTable = ({
   setHasModalSubmitted,
   fetchDevices,
   isSystemsView = false,
+  externalDataUpdate = false,
 }) => {
   const canBeRemoved = setRemoveModal;
   const canBeAdded = setIsAddModalOpen;
@@ -358,6 +359,7 @@ const DeviceTable = ({
           kebabItems={kebabItems}
           hasModalSubmitted={hasModalSubmitted}
           setHasModalSubmitted={setHasModalSubmitted}
+          externalDataUpdate={externalDataUpdate}
         />
       )}
     </>
@@ -390,6 +392,7 @@ DeviceTable.propTypes = {
   handleRemoveDevicesFromGroup: PropTypes.func,
   fetchDevices: PropTypes.func,
   isSystemsView: PropTypes.bool,
+  externalDataUpdate: PropTypes.bool,
 };
 
 export default DeviceTable;

--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -30,6 +30,7 @@ const Inventory = () => {
   const [isRowSelected, setIsRowSelected] = useState(false);
   const [hasModalSubmitted, setHasModalSubmitted] = useState(false);
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
+  const [tableReloadAfterUpdate, setTableRealoadAfterUpdate] = useState(false);
   const [updateModal, setUpdateModal] = useState({
     isOpen: false,
     deviceData: null,
@@ -67,6 +68,7 @@ const Inventory = () => {
           handleRemoveDevicesFromGroup={handleRemoveDevicesFromGroup}
           hasCheckbox={true}
           selectedItems={setCheckedDeviceIds}
+          externalDataUpdate={tableReloadAfterUpdate}
           kebabItems={[
             {
               isDisabled: !(checkedDeviceIds.length > 0),
@@ -107,6 +109,7 @@ const Inventory = () => {
             setUpdateModal={setUpdateModal}
             updateModal={updateModal}
             refreshTable={fetchDevices}
+            refreshPaginationIndex={setTableRealoadAfterUpdate}
           />
         </Suspense>
       )}

--- a/src/Routes/Devices/UpdateDeviceModal.js
+++ b/src/Routes/Devices/UpdateDeviceModal.js
@@ -32,7 +32,12 @@ const getImageData = (imageId) =>
     })
   );
 
-const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
+const UpdateDeviceModal = ({
+  updateModal,
+  setUpdateModal,
+  refreshTable,
+  refreshPaginationIndex,
+}) => {
   const [imageData, setImageData] = useState(null);
   const dispatch = useDispatch();
   const isMultiple = updateModal.deviceData.length > 1;
@@ -81,6 +86,7 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
 
     handleClose();
     refreshTable ? refreshTable() : null;
+    refreshTable ? refreshPaginationIndex(true) : null;
   };
 
   const handleClose = () => {
@@ -202,6 +208,7 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
 
 UpdateDeviceModal.propTypes = {
   refreshTable: PropTypes.func,
+  refreshPaginationIndex: PropTypes.func,
   updateModal: PropTypes.shape({
     isOpen: PropTypes.bool.isRequired,
     deviceData: PropTypes.array.isRequired,

--- a/src/components/general-table/GeneralTable.js
+++ b/src/components/general-table/GeneralTable.js
@@ -70,6 +70,7 @@ const GeneralTable = ({
   hasModalSubmitted,
   setHasModalSubmitted,
   isUseApi,
+  externalDataUpdate,
 }) => {
   const defaultCheckedRows = initSelectedItems ? initSelectedItems : [];
   const [filterValues, setFilterValues] = useState(createFilterValues(filters));
@@ -130,6 +131,12 @@ const GeneralTable = ({
     selectedItems && selectedItems(checkedRows);
     hasModalSubmitted && setHasModalSubmitted(false);
   }, [checkedRows]);
+
+  useEffect(() => {
+    if (externalDataUpdate) {
+      setPage(1);
+    }
+  }, [externalDataUpdate]);
 
   const { count, isLoading, hasError } = tableData;
 
@@ -321,7 +328,6 @@ const GeneralTable = ({
     : hasCheckbox
     ? checkboxRows()
     : filteredRows;
-
   return (
     <>
       <ToolbarHeader
@@ -405,11 +411,13 @@ GeneralTable.propTypes = {
   setHasModalSubmitted: PropTypes.func,
   initSelectedItems: PropTypes.array,
   isUseApi: PropTypes.bool,
+  externalDataUpdate: PropTypes.bool,
 };
 
 GeneralTable.defaultProps = {
   hasModalSubmitted: false,
   setHasModalSubmitted: () => {},
+  externalDataUpdate: false,
 };
 
 export default GeneralTable;


### PR DESCRIPTION
Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

# Description

This PR contains a bug fix for ticket 2084. The bug is about pagination index not refresh after external data source update trigged by update device. The root cause is because once the data source is external updated, generalTable component is not informed for it and keep the previous pagination index.

 This PR presents a solution to create a way to notify generalTable about a external trigged data source update, so we can reset the index for pagination and add this mechanism to be trigged by UpdateDeviceModal. 

This solution is current working and could be reused by any other screen using GeneralTable, but for a long term solution, maybe we can discuss as a team the possibility to move the refresh content ownership from external components to inside generalTable, in a way to avoid multiple screens contains logic/states to trigger this event to reset pagination and simplify the other screens/components.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted