### PR TITLE
image-wizard: FIXES default-image release when no selection.

### DIFF
--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -19,6 +19,7 @@ import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { getEdgeImageStatus } from '../../api';
 import { useFeatureFlags } from '../../constants';
+import { DEFAULT_RELEASE } from '../ImageManagerDetail/constants';
 
 const CreateImage = ({ navigateBack }) => {
   const [user, setUser] = useState();
@@ -101,7 +102,11 @@ const CreateImage = ({ navigateBack }) => {
         });
       }}
       defaultArch="x86_64"
-      initialValues={{ version: 0, includesCustomRepos: customRepoFlag }}
+      initialValues={{
+        version: 0,
+        release: DEFAULT_RELEASE,
+        includesCustomRepos: customRepoFlag,
+      }}
       schema={{
         fields: [
           {


### PR DESCRIPTION
When the release is not selected, no release is taken into account when creating a new image .

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted