### PR TITLE
Remove strange npm proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14990,7 +14990,7 @@
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/memorystream/-/memorystream-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true,
       "engines": {
@@ -15889,7 +15889,7 @@
     },
     "node_modules/npm-run-all/node_modules/cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "dependencies": {
@@ -15905,7 +15905,7 @@
     },
     "node_modules/npm-run-all/node_modules/load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "dependencies": {
@@ -15920,7 +15920,7 @@
     },
     "node_modules/npm-run-all/node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "dependencies": {
@@ -15954,7 +15954,7 @@
     },
     "node_modules/npm-run-all/node_modules/read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "dependencies": {
@@ -15968,7 +15968,7 @@
     },
     "node_modules/npm-run-all/node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true,
       "engines": {
@@ -34611,7 +34611,7 @@
     },
     "memorystream": {
       "version": "0.3.1",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/memorystream/-/memorystream-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
@@ -35281,7 +35281,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
@@ -35294,7 +35294,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
@@ -35306,7 +35306,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -35331,7 +35331,7 @@
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -35342,7 +35342,7 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/strip-bom/-/strip-bom-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }


### PR DESCRIPTION
# Description
There's a strange npm proxy server on couple of dependencies.

Fixes # (issue)
Remove this proxy and use just plain `npmjs` to fetch the packages.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update