### PR TITLE
Add rhel 86 & 90 to image wizard

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -119,16 +119,20 @@ export const imageStatusMapper = {
 export const distributionMapper = {
   'rhel-84': 'RHEL 8.4',
   'rhel-85': 'RHEL 8.5',
+  'rhel-86': 'RHEL 8.6',
+  'rhel-90': 'RHEL 9.0',
 };
 
 export const releaseMapper = {
+  'rhel-90': 'Red Hat Enterprise Linux (RHEL) 9.0',
+  'rhel-86': 'Red Hat Enterprise Linux (RHEL) 8.6',
   'rhel-85': 'Red Hat Enterprise Linux (RHEL) 8.5',
   'rhel-84': 'Red Hat Enterprise Linux (RHEL) 8.4',
 };
 
-export const supportedReleases = ['rhel-84', 'rhel-85'];
+export const supportedReleases = ['rhel-84', 'rhel-85', 'rhel-86', 'rhel-90'];
 
-export const DEFAULT_RELEASE = 'rhel-85';
+export const DEFAULT_RELEASE = 'rhel-90';
 
 export const imageTypeMapper = {
   'rhel-edge-commit': 'RHEL for Edge Commit (.tar)',


### PR DESCRIPTION
# Description

Add rhel 86 & 90 to image wizard and set rhel 90 as default release

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted