### PR TITLE
fixed issue where image sets wasnt reloading after c/u wizard

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -68,7 +68,7 @@ const columnNames = [
   },
 ];
 
-const createRows = (devices, isSystemsView) => {
+const createRows = (devices, hasLinks) => {
   return devices?.map((device) => {
     let { DeviceName, DeviceGroups } = device;
 
@@ -128,7 +128,7 @@ const createRows = (devices, isSystemsView) => {
       ],
       cells: [
         {
-          title: isSystemsView ? (
+          title: hasLinks ? (
             <Link to={`${paths['inventory']}/${DeviceUUID}`}>{DeviceName}</Link>
           ) : (
             DeviceName
@@ -136,7 +136,7 @@ const createRows = (devices, isSystemsView) => {
         },
         {
           title: ImageName ? (
-            isSystemsView ? (
+            hasLinks ? (
               <Link to={`${paths['manage-images']}/${ImageSetID}/`}>
                 {ImageName}
               </Link>
@@ -186,6 +186,7 @@ const DeviceTable = ({
   setHasModalSubmitted,
   fetchDevices,
   isSystemsView = false,
+  isAddSystemsView = false,
 }) => {
   const canBeRemoved = setRemoveModal;
   const canBeAdded = setIsAddModalOpen;
@@ -300,7 +301,7 @@ const DeviceTable = ({
             hasError: hasError,
           }}
           columnNames={columnNames}
-          rows={createRows(data || [], isSystemsView)}
+          rows={createRows(data || [], isAddSystemsView || isSystemsView)}
           actionResolver={actionResolver}
           defaultSort={{ index: 3, direction: 'desc' }}
           toolbarButtons={
@@ -351,6 +352,7 @@ DeviceTable.propTypes = {
   handleRemoveDevicesFromGroup: PropTypes.func,
   fetchDevices: PropTypes.func,
   isSystemsView: PropTypes.bool,
+  isAddSystemsView: PropTypes.bool,
 };
 
 export default DeviceTable;

--- a/src/Routes/GroupsDetail/GroupsDetail.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.js
@@ -268,6 +268,7 @@ const GroupsDetail = () => {
             hasModalSubmitted={hasModalSubmitted}
             setHasModalSubmitted={setHasModalSubmitted}
             fetchDevices={fetchDevices}
+            isAddSystemsView={true}
           />
         ) : (
           <Flex justifyContent={{ default: 'justifyContentCenter' }}>

--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -13,15 +13,14 @@ import {
 import { Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import ReviewStep from '../../components/form/ReviewStep';
-import { createNewImage, loadEdgeImageSets } from '../../store/actions';
-import { CREATE_NEW_IMAGE_RESET } from '../../store/action-types';
+import { createNewImage } from '../../store/actions';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { getEdgeImageStatus } from '../../api/images';
 import { useFeatureFlags } from '../../utils';
 import { DEFAULT_RELEASE, TEMPORARY_RELEASE } from '../../constants';
 
-const CreateImage = ({ navigateBack }) => {
+const CreateImage = ({ navigateBack, reload }) => {
   const [user, setUser] = useState();
   const dispatch = useDispatch();
   const customRepoFlag = useFeatureFlags('fleet-management.custom-repos');
@@ -31,7 +30,7 @@ const CreateImage = ({ navigateBack }) => {
 
   const closeAction = () => {
     navigateBack();
-    dispatch({ type: CREATE_NEW_IMAGE_RESET });
+    reload && reload();
   };
   useEffect(() => {
     (async () => {
@@ -94,13 +93,11 @@ const CreateImage = ({ navigateBack }) => {
                           description: `${resp.value.Name} image build is completed`,
                         })
                       ),
-                    (dispatch) => loadEdgeImageSets(dispatch),
                   ],
                 },
               },
             },
           });
-          loadEdgeImageSets(dispatch);
           closeAction();
         });
       }}
@@ -154,6 +151,7 @@ const CreateImage = ({ navigateBack }) => {
 
 CreateImage.propTypes = {
   navigateBack: PropTypes.func,
+  reload: PropTypes.func,
 };
 CreateImage.defaultProps = {
   navigateBack: () => undefined,

--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -89,6 +89,13 @@ const Images = () => {
               });
               setIsCreateWizardOpen(false);
             }}
+            reload={() =>
+              fetchImageSets({
+                limit: 20,
+                offset: 0,
+                sort_by: '-updated_at',
+              })
+            }
           />
         </Suspense>
       )}
@@ -113,6 +120,13 @@ const Images = () => {
                 };
               });
             }}
+            reload={() =>
+              fetchImageSets({
+                limit: 20,
+                offset: 0,
+                sort_by: '-updated_at',
+              })
+            }
             updateImageID={UpdateWizard.imageId}
           />
         </Suspense>

--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -89,13 +89,7 @@ const Images = () => {
               });
               setIsCreateWizardOpen(false);
             }}
-            reload={() =>
-              fetchImageSets({
-                limit: 20,
-                offset: 0,
-                sort_by: '-updated_at',
-              })
-            }
+            reload={fetchImageSets}
           />
         </Suspense>
       )}
@@ -120,13 +114,7 @@ const Images = () => {
                 };
               });
             }}
-            reload={() =>
-              fetchImageSets({
-                limit: 20,
-                offset: 0,
-                sort_by: '-updated_at',
-              })
-            }
+            reload={fetchImageSets}
             updateImageID={UpdateWizard.imageId}
           />
         </Suspense>

--- a/src/Routes/ImageManager/UpdateImageWizard.js
+++ b/src/Routes/ImageManager/UpdateImageWizard.js
@@ -14,23 +14,22 @@ import { Bullseye, Backdrop, Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import ReviewStep from '../../components/form/ReviewStep';
 import { createNewImage, addImageToPoll } from '../../store/actions';
-import { CREATE_NEW_IMAGE_RESET } from '../../store/action-types';
 import { useDispatch } from 'react-redux';
 import { useSelector, shallowEqual } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { imageDetailReducer } from '../../store/reducers';
-import { loadImageDetail, loadEdgeImageSets } from '../../store/actions';
+import { loadImageDetail } from '../../store/actions';
 import { getEdgeImageStatus } from '../../api/images';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useFeatureFlags, getReleases } from '../../utils';
 import { temporaryReleases, supportedReleases } from '../../constants';
 
-const UpdateImage = ({ navigateBack, updateImageID }) => {
+const UpdateImage = ({ navigateBack, updateImageID, reload }) => {
   const [user, setUser] = useState();
   const dispatch = useDispatch();
   const closeAction = () => {
     navigateBack();
-    dispatch({ type: CREATE_NEW_IMAGE_RESET });
+    reload && reload();
   };
   const customRepoFlag = useFeatureFlags('fleet-management.custom-repos');
   const temporaryReleasesFlag = useFeatureFlags(
@@ -124,14 +123,12 @@ const UpdateImage = ({ navigateBack, updateImageID }) => {
                           description: `${resp.value.Name} image build is completed`,
                         })
                       ),
-                    (dispatch) => loadEdgeImageSets(dispatch),
                   ],
                 },
               },
             },
           });
           closeAction();
-          loadEdgeImageSets(dispatch);
           dispatch(
             addImageToPoll({ name: data.value.Name, id: data.value.ID })
           );
@@ -217,6 +214,7 @@ const UpdateImage = ({ navigateBack, updateImageID }) => {
 UpdateImage.propTypes = {
   navigateBack: PropTypes.func,
   updateImageID: PropTypes.number,
+  reload: PropTypes.func,
 };
 UpdateImage.defaultProps = {
   navigateBack: () => undefined,

--- a/src/api/images/index.js
+++ b/src/api/images/index.js
@@ -136,6 +136,7 @@ export const getImageById = ({ id }) => {
 };
 
 export const getImageSets = ({ query }) => {
+  console.log(query);
   const q = getTableParams(query);
   return instance.get(`${EDGE_API}/image-sets?${q}`);
 };

--- a/src/api/images/index.js
+++ b/src/api/images/index.js
@@ -136,7 +136,9 @@ export const getImageById = ({ id }) => {
 };
 
 export const getImageSets = ({ query }) => {
-  console.log(query);
+  if (query === '') {
+    query = { limit: 20, offset: 0, sort_by: '-updated_at' };
+  }
   const q = getTableParams(query);
   return instance.get(`${EDGE_API}/image-sets?${q}`);
 };


### PR DESCRIPTION
# Description

Fixed issue where image sets was not reloading after going through create and update wizard. This was due to the recent change from switching over the image sets to the useAPI hook. Last steps to complete that switchover

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted