### PR TITLE
Change imageset details limit from 20 to 10

### DIFF
--- a/src/api/images/index.js
+++ b/src/api/images/index.js
@@ -71,7 +71,7 @@ export const createImage = ({
 export const getImageSet = ({
   id,
   q = {
-    limit: 20,
+    limit: 10,
     offset: 0,
     sort_by: '-created_at',
   },


### PR DESCRIPTION
# Description

Change image-set details limit from 20 to 10 to fix an error when trying to return more then 10 images in an image-set

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted