### PR TITLE
Fix system update when image is building

### DIFF
--- a/src/Routes/Devices/UpdateDeviceModal.js
+++ b/src/Routes/Devices/UpdateDeviceModal.js
@@ -45,6 +45,7 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
           q: {
             limit: 1,
             sort_by: '-created_at',
+            status: 'SUCCESS',
           },
         }).then((data) => setImageData(data.Data.images[0]))
       : getImageData(updateModal.imageId).then((data) =>


### PR DESCRIPTION
# Description

Fix system update when latest image is building so that only the latest image that was successfully built is shown as the image to update to

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted