### PR TITLE
Fix PropTypes for CreateGroupButton

### DIFF
--- a/src/Routes/Devices/AddDeviceModal.js
+++ b/src/Routes/Devices/AddDeviceModal.js
@@ -26,7 +26,7 @@ const CreateGroupButton = ({ openModal }) => (
 );
 
 CreateGroupButton.propTypes = {
-  openModal: PropTypes.bool,
+  openModal: PropTypes.func,
 };
 
 const createDescription = (deviceIds) => {


### PR DESCRIPTION
# Description

This PR fixes the following issue:

- On Inventory > Systems, select one or more systems.
- Click the kebab in the toolbar above the table, and select 'Add to group'.
- In the browser console, see the following:

```
Warning: Failed prop type: Invalid prop `openModal` of type `function` supplied to `CreateGroupButton`, expected `boolean`.
CreateGroupButton@https://stage.foo.redhat.com:1337/beta/apps/edge/js/GroupsDetailPage.js:903:19
SingleField@https://stage.foo.redhat.com:1337/beta/apps/edge/js/vendors-node_modules_data-driven-forms_pf4-component-mapper_esm_component-mapper_index_js-nod-3f2bf3.js:7800:19
form
Form@https://stage.foo.redhat.com:1337/beta/apps/edge/edge.1658174145833.b50d97cf46c00457d289.js:11302:93
[...]
```

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted