### PR TITLE
Fix SearchInput to call API when filtering.

### DIFF
--- a/src/Routes/Devices/AddDeviceModal.js
+++ b/src/Routes/Devices/AddDeviceModal.js
@@ -4,17 +4,10 @@ import validatorTypes from '@data-driven-forms/react-form-renderer/validator-typ
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import Modal from '../../components/Modal';
 import SearchInput from '../../components/SearchInput';
-import useApi from '../../hooks/useApi';
 import apiWithToast from '../../utils/apiWithToast';
-import { getGroups, addDevicesToGroup } from '../../api/groups';
+import { addDevicesToGroup } from '../../api/groups';
 import { useDispatch } from 'react-redux';
-import {
-  Backdrop,
-  Bullseye,
-  Spinner,
-  Button,
-  Text,
-} from '@patternfly/react-core';
+import { Button, Text } from '@patternfly/react-core';
 
 const CreateGroupButton = ({ openModal }) => (
   <>
@@ -48,7 +41,7 @@ const createSchema = (deviceIds) => ({
     },
     {
       component: 'search-input',
-      name: 'name',
+      name: 'group',
       label: 'Select a group',
       isRequired: true,
       validate: [{ type: validatorTypes.REQUIRED }],
@@ -65,8 +58,6 @@ const AddDeviceModal = ({
   deviceIds,
 }) => {
   const dispatch = useDispatch();
-  const [response] = useApi({ api: getGroups });
-  const { data, isLoading } = response;
 
   const handleAddDevices = (values) => {
     const { group } = values;
@@ -84,13 +75,7 @@ const AddDeviceModal = ({
       statusMessages
     );
   };
-  return isLoading ? (
-    <Backdrop>
-      <Bullseye>
-        <Spinner isSVG diameter="100px" />
-      </Bullseye>
-    </Backdrop>
-  ) : (
+  return (
     <Modal
       isOpen={isModalOpen}
       openModal={() => setIsModalOpen(false)}
@@ -99,7 +84,6 @@ const AddDeviceModal = ({
       additionalMappers={{
         'search-input': {
           component: SearchInput,
-          defaultOptions: data?.data || [],
         },
         'create-group-btn': {
           component: CreateGroupButton,


### PR DESCRIPTION
# Description

Previously, `AddDeviceModal` would get the list of device groups from the backend API, and then pass this list to `SearchInput` for the user to filter and select from. The backend only returns the 30 most recently created groups by default, however, so any other groups can't be seen or selected in this modal.

This PR updates `SearchInput` so that it calls the `getGroups` API whenever the user enters search text into the typeahead input field. If the API response indicates that there are more results than displayed, then warning text will appear above the search field: "Over 30 results found. Refine your search." Also, the dropdown will display "Loading..." while waiting for the API response.

This PR also fixes a couple bugs:
- The data-driven-forms schema in `AddDeviceModal` named the form's group field `name`, but `SearchInput` uses `group` for the field name. Now the field is named `group` in both places.
- `SearchInput` did not use the `useFieldApi` hook to register the `group` field. Without this hook, updates to the `group` field did not also update the form state, which prevented the `Add` button from being disabled when a group is not yet selected.
- `SearchInput` did not unset the group field value when the user clears the group selection. The user could still click `Add`, and the system would still be added to the group. With this fix, clicking the unselect icon unsets the field value and disables the `Add` button, as expected.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted