### PR TITLE
Create registry only during initial render of AppEntry

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -8,7 +8,8 @@ import { getBaseName } from '@redhat-cloud-services/frontend-components-utilitie
 import logger from 'redux-logger';
 
 const AppEntry = ({ hasLogger }) => {
-  const registry = hasLogger ? init(logger) : init(logger);
+  // Initialize reducer registry only at initial render.
+  const registry = useMemo(() => (hasLogger ? init(logger) : init()), []);
   return (
     <RegistryContext.Provider
       value={{


### PR DESCRIPTION
# Description

This PR fixes an issue with toast notifications not displaying. Because `registry` is re-initialized every time the `AppEntry` component is rendered, the Redux store would also get wiped out every time you click on a different navigation item (Groups / Systems / Repositories, etc.). (This happens in the stage environment, where React's dev mode will re-render `AppEntry` each time. This would cause toast notifications to stop appearing.

The registry and store creation have been memoized with the React `useMemo` hook, so that they are only created during the first render.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted