### PR TITLE
Fix broken eager consumption by using latest version of FEC config

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -13,6 +13,9 @@ const webpackProxy = {
     process.env.BETA ? 'beta' : 'stable'
   }`, // for accessing prod-beta start your app with ENVIRONMENT=prod and BETA=true
   appUrl: process.env.BETA ? '/beta/edge' : '/edge',
+  ...(process.env.INSIGHTS_CHROME && {
+    localChrome: process.env.INSIGHTS_CHROME,
+  }),
   routes: {
     ...(process.env.API_PORT && {
       '/api/edge': { host: `http://localhost:${process.env.API_PORT}` },

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@babel/preset-react": "7.14.5",
         "@cypress/code-coverage": "^3.10.0",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "1.2.1",
-        "@redhat-cloud-services/frontend-components-config": "4.6.13",
+        "@redhat-cloud-services/frontend-components-config": "4.6.18",
         "@testing-library/react": "^12.1.5",
         "@webpack-cli/serve": "^1.6.1",
         "babel-core": "7.0.0-bridge.0",
@@ -4631,12 +4631,12 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "4.6.13",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.13.tgz",
-      "integrity": "sha512-gR7AZbhskY4dm7nU4CM14pch90/xDzcDlnJev+yne9lCt0amdy8SJ7FRLIxCeoVFAARNXuMctuTDkua/LPpMHQ==",
+      "version": "4.6.18",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.18.tgz",
+      "integrity": "sha512-arwJsMuAbpfUWsI/nK0gom/WNxhVLaXuj0gxwZOIgQ61ZunOcoINKj+AxkeXpxpzMR4zmMWFbv0+y4PUbqXOhw==",
       "dev": true,
       "dependencies": {
-        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.23",
         "assert": "^2.0.0",
         "axios": "^0.25.0",
         "babel-loader": "^8.2.2",
@@ -4670,7 +4670,6 @@
         "webpack": "^5.55.1",
         "webpack-cli": "^4.8.0",
         "webpack-dev-server": "4.8.1",
-        "write-file-webpack-plugin": "^4.5.1",
         "yargs": "^17.2.1"
       },
       "bin": {
@@ -4678,9 +4677,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "1.5.19",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.19.tgz",
-      "integrity": "sha512-4mvxmvJXtdTivPOy/n79zbDO8MDSTgdj/PFmF3ZrghoFtCZjdCDhTuUwSXOwzgurlRYkB3UiKnNh1KbwmUC9Hw==",
+      "version": "1.5.23",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.23.tgz",
+      "integrity": "sha512-pYdbF9NTJ2wgYpG49cNXVCbi0Yv+xss18pPjx2RDVlV+Fe+u9l+WtxG2GzpOGxx2w4UnpMtFgQH9nbe045lYCQ==",
       "dev": true,
       "dependencies": {
         "node-fetch": "2.6.7"
@@ -11208,15 +11207,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "node_modules/filesize": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -16735,15 +16725,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -24717,44 +24698,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "devOptional": true
     },
-    "node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/write-file-webpack-plugin": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.5.1.tgz",
-      "integrity": "sha512-AZ7qJUvhTCBiOtG21aFJUcNuLVo2FFM6JMGKvaUGAH+QDqQAp2iG0nq3GcuXmJOFQR2JjpjhyYkyPrbFKhdjNQ==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.0",
-        "debug": "^3.1.0",
-        "filesize": "^3.6.1",
-        "lodash": "^4.17.13",
-        "mkdirp": "^0.5.1",
-        "moment": "^2.22.1",
-        "write-file-atomic": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/write-file-webpack-plugin/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/ws": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
@@ -28322,12 +28265,12 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "4.6.13",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.13.tgz",
-      "integrity": "sha512-gR7AZbhskY4dm7nU4CM14pch90/xDzcDlnJev+yne9lCt0amdy8SJ7FRLIxCeoVFAARNXuMctuTDkua/LPpMHQ==",
+      "version": "4.6.18",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.18.tgz",
+      "integrity": "sha512-arwJsMuAbpfUWsI/nK0gom/WNxhVLaXuj0gxwZOIgQ61ZunOcoINKj+AxkeXpxpzMR4zmMWFbv0+y4PUbqXOhw==",
       "dev": true,
       "requires": {
-        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.23",
         "assert": "^2.0.0",
         "axios": "^0.25.0",
         "babel-loader": "^8.2.2",
@@ -28361,7 +28304,6 @@
         "webpack": "^5.55.1",
         "webpack-cli": "^4.8.0",
         "webpack-dev-server": "4.8.1",
-        "write-file-webpack-plugin": "^4.5.1",
         "yargs": "^17.2.1"
       },
       "dependencies": {
@@ -28895,9 +28837,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "1.5.19",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.19.tgz",
-      "integrity": "sha512-4mvxmvJXtdTivPOy/n79zbDO8MDSTgdj/PFmF3ZrghoFtCZjdCDhTuUwSXOwzgurlRYkB3UiKnNh1KbwmUC9Hw==",
+      "version": "1.5.23",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.23.tgz",
+      "integrity": "sha512-pYdbF9NTJ2wgYpG49cNXVCbi0Yv+xss18pPjx2RDVlV+Fe+u9l+WtxG2GzpOGxx2w4UnpMtFgQH9nbe045lYCQ==",
       "dev": true,
       "requires": {
         "node-fetch": "2.6.7"
@@ -33496,12 +33438,6 @@
         }
       }
     },
-    "filesize": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-      "dev": true
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -37607,12 +37543,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -43660,43 +43590,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "devOptional": true
-    },
-    "write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "write-file-webpack-plugin": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.5.1.tgz",
-      "integrity": "sha512-AZ7qJUvhTCBiOtG21aFJUcNuLVo2FFM6JMGKvaUGAH+QDqQAp2iG0nq3GcuXmJOFQR2JjpjhyYkyPrbFKhdjNQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.0",
-        "debug": "^3.1.0",
-        "filesize": "^3.6.1",
-        "lodash": "^4.17.13",
-        "mkdirp": "^0.5.1",
-        "moment": "^2.22.1",
-        "write-file-atomic": "^2.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
     },
     "ws": {
       "version": "8.7.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",
     "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
     "start:proxy": "PROXY=true NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
+    "start:federated": "BETA=true fec static --config config/dev.webpack.config.js",
     "test": "jest --verbose",
     "verify": "npm-run-all build lint test",
     "prepare": "husky install"
@@ -83,7 +84,7 @@
     "@babel/preset-react": "7.14.5",
     "@cypress/code-coverage": "^3.10.0",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "1.2.1",
-    "@redhat-cloud-services/frontend-components-config": "4.6.13",
+    "@redhat-cloud-services/frontend-components-config": "4.6.18",
     "@testing-library/react": "^12.1.5",
     "@webpack-cli/serve": "^1.6.1",
     "babel-core": "7.0.0-bridge.0",


### PR DESCRIPTION
# Description

There's a BZ with error when switching from inventory to edge https://bugzilla.redhat.com/show_bug.cgi?id=2115372. This PR updates the config package to latest version to fix this issue (there's an error with eager consumption of react-router-dom).

I've also included an option to serve local chrome with `INSIGHTS_CHROME` variable as `INSIGHTS_CHROME=/home/khala/Documents/git/RedhatInsights/insights-chrome/dist npm run start:proxy`.

And while testing this I needed to run the chrome in federated mode alongside with inventory, so I added a simple `start:federated` which serves federated modules for consumption from inventory.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)