### PR TITLE
Change remaining 'device' strings to 'system'.

### DIFF
--- a/cypress/fixtures/contents.json
+++ b/cypress/fixtures/contents.json
@@ -6,6 +6,6 @@
 "edgeCommitContent":"An OSTree commit is always created when building an image.",
 "edgeInstallerContent":"An installable version of the image is typically created with a brand new image.",
 "optionsContent":"Enter some basic information about your image.",
-"deviceRegistrationContent":"Use this to log into your device."
+"deviceRegistrationContent":"Use this to log into your system."
 
 }

--- a/src/Routes/Devices/AddDeviceModal.js
+++ b/src/Routes/Devices/AddDeviceModal.js
@@ -73,9 +73,9 @@ const AddDeviceModal = ({
     const statusMessages = {
       onSuccess: {
         title: 'Success',
-        description: `Device(s) have been added to ${group.toString()} successfully`,
+        description: `System(s) have been added to ${group.toString()} successfully`,
       },
-      onError: { title: 'Error', description: 'Failed to add device to group' },
+      onError: { title: 'Error', description: 'Failed to add system to group' },
     };
 
     apiWithToast(

--- a/src/Routes/Devices/AddSystemsToGroupModal.js
+++ b/src/Routes/Devices/AddSystemsToGroupModal.js
@@ -27,7 +27,7 @@ const AddSystemsToGroupModal = ({
     const statusMessages = {
       onSuccess: {
         title: 'Success',
-        description: `Device(s) have been added to ${groupName} successfully`,
+        description: `System(s) have been added to ${groupName} successfully`,
       },
       onError: {
         title: 'Error',

--- a/src/Routes/Devices/RemoveDeviceModal.js
+++ b/src/Routes/Devices/RemoveDeviceModal.js
@@ -87,7 +87,7 @@ const RemoveDeviceModal = ({
       },
       onError: {
         title: 'Error',
-        description: 'Failed to remove device from group',
+        description: 'Failed to remove system from group',
       },
     };
 

--- a/src/Routes/Devices/UpdateDeviceModal.js
+++ b/src/Routes/Devices/UpdateDeviceModal.js
@@ -61,7 +61,7 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
       dispatch({
         ...addNotification({
           variant: 'info',
-          title: 'Updating device',
+          title: 'Updating system',
           description: isMultiple
             ? ` ${deviceName.length} systems were added to the queue.`
             : ` ${deviceName} was added to the queue.`,
@@ -71,7 +71,7 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
       dispatch({
         ...addNotification({
           variant: 'danger',
-          title: 'Updating a device was unsuccessful',
+          title: 'Updating a system was unsuccessful',
           description: `Response: ${err.statusText}`,
         }),
       });
@@ -96,7 +96,7 @@ const UpdateDeviceModal = ({ updateModal, setUpdateModal, refreshTable }) => {
         style={{ color: 'var(--pf-global--palette--gold-500)' }}
         component="small"
       >
-        <ExclamationTriangleIcon /> After the update is installed, the device
+        <ExclamationTriangleIcon /> After the update is installed, the system
         will apply the changes.
       </Text>
     </TextContent>

--- a/src/Routes/Groups/CreateGroupModal.js
+++ b/src/Routes/Groups/CreateGroupModal.js
@@ -79,7 +79,7 @@ const CreateGroupModal = ({
     const statusMessages = {
       onSuccess: {
         title: 'Success',
-        description: `system(s) have been added to ${values.name} successfully`,
+        description: `System(s) have been added to ${values.name} successfully`,
       },
       onError: { title: 'Error', description: 'Failed to add system to group' },
     };

--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -17,7 +17,7 @@ const WarningInstallerHelperText = () => (
   <HelperText className="pf-u-ml-lg" hasIcon>
     <HelperTextItem className="pf-u-pb-md" variant="warning" hasIcon>
       Creating an installable version of your image increases the build time and
-      is not needed for updating existing devices. <br />
+      is not needed for updating existing systems. <br />
       You can create an installable version of this image later if you continue
       with this option
     </HelperTextItem>

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -85,7 +85,7 @@ export const loadImages = (dispatch, pagination) => {
       notifications: {
         rejected: {
           variant: 'danger',
-          title: 'Can not show images data',
+          title: 'Cannot show images data',
           description: 'Failed receiving images from image-builder',
         },
       },
@@ -104,8 +104,8 @@ export const loadDeviceSummary = (dispatch) => {
       notifications: {
         rejected: {
           variant: 'danger',
-          title: 'Can not show device summary data',
-          description: 'Failed receiving device summary data from inventory',
+          title: 'Cannot show system summary data',
+          description: 'Failed receiving system summary data from inventory',
         },
       },
     },

--- a/src/store/deviceSummary.js
+++ b/src/store/deviceSummary.js
@@ -21,7 +21,7 @@ const loadDeviceSummaryFulfilled = (state, { payload }) => {
 const loadDeviceSummaryRejected = () => ({
   isLoading: false,
   hasError: true,
-  data: 'No device summary data to view',
+  data: 'No system summary data to view',
 });
 
 export default applyReducerHash(

--- a/src/store/deviceSummary.test.js
+++ b/src/store/deviceSummary.test.js
@@ -34,7 +34,7 @@ describe('reducer', () => {
     ).toMatchObject({
       isLoading: false,
       hasError: true,
-      data: 'No device summary data to view',
+      data: 'No system summary data to view',
     });
   });
 });


### PR DESCRIPTION
# Description

This PR changes a few instances of UI text from 'system' to 'device' that were not changed by a previous PR:

Fix UI display text from device to system
https://github.com/RedHatInsights/edge-frontend/pull/526

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted