### PR TITLE
Restore non-API SearchInput component for RemoveDeviceModal

### DIFF
--- a/src/Routes/Devices/AddDeviceModal.js
+++ b/src/Routes/Devices/AddDeviceModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import Modal from '../../components/Modal';
-import SearchInput from '../../components/SearchInput';
+import SearchInputApi from '../../components/SearchInputApi';
 import apiWithToast from '../../utils/apiWithToast';
 import { addDevicesToGroup } from '../../api/groups';
 import { useDispatch } from 'react-redux';
@@ -83,7 +83,7 @@ const AddDeviceModal = ({
       submitLabel="Add"
       additionalMappers={{
         'search-input': {
-          component: SearchInput,
+          component: SearchInputApi,
         },
         'create-group-btn': {
           component: CreateGroupButton,

--- a/src/Routes/Devices/RemoveDeviceModal.js
+++ b/src/Routes/Devices/RemoveDeviceModal.js
@@ -54,7 +54,7 @@ const createSchema = (deviceInfo) => {
   if (deviceInfo[0].deviceGroups.length > 1) {
     schema.fields.push({
       component: 'search-input',
-      name: 'name',
+      name: 'group',
       label: 'Select a group',
       isRequired: true,
       validate: [{ type: validatorTypes.REQUIRED }],

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -1,27 +1,16 @@
-import React, { Fragment, useState } from 'react';
-import {
-  HelperText,
-  HelperTextItem,
-  Select,
-  SelectOption,
-} from '@patternfly/react-core';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Select, SelectOption } from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
-import useApi from '../hooks/useApi';
-import { getGroups } from '../api/groups';
-import { debounce } from 'lodash';
 
-const SelectInput = (props) => {
+const SelectInputApi = (props) => {
   useFieldApi(props);
   const { change } = useFormApi();
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState(null);
-  const [{ data, isLoading }, fetchGroups] = useApi({ api: getGroups });
-  const [searchTerm, setSearchTerm] = useState('');
 
-  const onToggle = (isOpen) => {
-    setIsOpen(isOpen);
-  };
+  const onToggle = (isOpen) => setIsOpen(isOpen);
 
   const onSelect = (_event, selection, isPlaceholder) => {
     if (isPlaceholder) clearSelection();
@@ -36,35 +25,10 @@ const SelectInput = (props) => {
     setSelected(null);
     change('group', null);
     setIsOpen(false);
-    setSearchTerm('');
   };
-
-  const onFilter = (_event, value) => {
-    /* This handler is called on input changes as well as when children change.
-       _event is null when the children change. Only update searchTerm state
-       if there was an actual input change.
-    */
-    if (_event && value != searchTerm) {
-      setSearchTerm(value);
-      fetchGroups({ name: encodeURIComponent(value) });
-    }
-  };
-
-  const options = data?.data || [];
-  const totalCount = data?.count || 0;
 
   return (
-    <Fragment>
-      <HelperText>
-        {!isLoading && !selected && totalCount > options.length ? (
-          <HelperTextItem variant="warning">
-            Over {options.length} results found. Refine your search.
-          </HelperTextItem>
-        ) : (
-          // Add empty helper text to prevent changes in vertical alignment
-          <HelperTextItem className="pf-u-pt-lg"></HelperTextItem>
-        )}
-      </HelperText>
+    <>
       <Select
         variant="typeahead"
         typeAheadAriaLabel="Select a state"
@@ -73,28 +37,28 @@ const SelectInput = (props) => {
         onClear={clearSelection}
         selections={selected}
         isOpen={isOpen}
-        onFilter={debounce(onFilter, 300)}
         aria-labelledby="typeahead-select-id-1"
-        placeholderText="Type or click to select a group"
-        noResultsFoundText={isLoading ? 'Loading...' : 'No results found'}
+        placeholderText="Type or click select group"
       >
-        {isLoading
-          ? []
-          : options?.map(({ DeviceGroup }) => (
-              <SelectOption
-                key={DeviceGroup.ID}
-                value={{
-                  toString: () => DeviceGroup.Name,
-                  groupId: DeviceGroup.ID,
-                }}
-                {...(DeviceGroup.description && {
-                  description: DeviceGroup.description,
-                })}
-              />
-            ))}
+        {props.defaultOptions.map(({ DeviceGroup }, index) => (
+          <SelectOption
+            key={index}
+            value={{
+              toString: () => DeviceGroup.Name,
+              groupId: DeviceGroup.ID,
+            }}
+            {...(DeviceGroup.description && {
+              description: DeviceGroup.description,
+            })}
+          />
+        ))}
       </Select>
-    </Fragment>
+    </>
   );
 };
 
-export default SelectInput;
+SelectInputApi.propTypes = {
+  defaultOptions: PropTypes.array,
+};
+
+export default SelectInputApi;

--- a/src/components/SearchInputApi.js
+++ b/src/components/SearchInputApi.js
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import {
+  HelperText,
+  HelperTextItem,
+  Select,
+  SelectOption,
+} from '@patternfly/react-core';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import useApi from '../hooks/useApi';
+import { getGroups } from '../api/groups';
+import { debounce } from 'lodash';
+
+const SelectInput = (props) => {
+  useFieldApi(props);
+  const { change } = useFormApi();
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const [{ data, isLoading }, fetchGroups] = useApi({ api: getGroups });
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const onToggle = (isOpen) => {
+    setIsOpen(isOpen);
+  };
+
+  const onSelect = (_event, selection, isPlaceholder) => {
+    if (isPlaceholder) clearSelection();
+    else {
+      setSelected(selection);
+      setIsOpen(false);
+    }
+    change('group', selection);
+  };
+
+  const clearSelection = () => {
+    setSelected(null);
+    change('group', null);
+    setIsOpen(false);
+    setSearchTerm('');
+  };
+
+  const onFilter = (_event, value) => {
+    /* This handler is called on input changes as well as when children change.
+       _event is null when the children change. Only update searchTerm state
+       if there was an actual input change.
+    */
+    if (_event && value != searchTerm) {
+      setSearchTerm(value);
+      fetchGroups({ name: encodeURIComponent(value) });
+    }
+  };
+
+  const options = data?.data || [];
+  const totalCount = data?.count || 0;
+
+  return (
+    <>
+      <HelperText>
+        {!isLoading && !selected && totalCount > options.length ? (
+          <HelperTextItem variant="warning">
+            Over {options.length} results found. Refine your search.
+          </HelperTextItem>
+        ) : (
+          // Add empty helper text to prevent changes in vertical alignment
+          <HelperTextItem className="pf-u-pt-lg"></HelperTextItem>
+        )}
+      </HelperText>
+      <Select
+        variant="typeahead"
+        typeAheadAriaLabel="Select a state"
+        onToggle={onToggle}
+        onSelect={onSelect}
+        onClear={clearSelection}
+        selections={selected}
+        isOpen={isOpen}
+        onFilter={debounce(onFilter, 300)}
+        aria-labelledby="typeahead-select-id-1"
+        placeholderText="Type or click to select a group"
+        noResultsFoundText={isLoading ? 'Loading...' : 'No results found'}
+      >
+        {isLoading
+          ? []
+          : options?.map(({ DeviceGroup }) => (
+              <SelectOption
+                key={DeviceGroup.ID}
+                value={{
+                  toString: () => DeviceGroup.Name,
+                  groupId: DeviceGroup.ID,
+                }}
+                {...(DeviceGroup.description && {
+                  description: DeviceGroup.description,
+                })}
+              />
+            ))}
+      </Select>
+    </>
+  );
+};
+
+export default SelectInput;


### PR DESCRIPTION
# Description

The changes to `SearchInput` in https://github.com/RedHatInsights/edge-frontend/pull/512 introduced a problem with `RemoveDeviceModal`: if you click `Remove from Group` for a system that is in more than one group, the select dropdown shows all groups (up to the default API limit of 30), instead of showing only the system's groups.

This PR restores the original static `SearchInput` component, and renames the modified component from the previous PR to `SearchInputApi`.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted