### PR TITLE
Fix table sorting after modal submit

### DIFF
--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -50,9 +50,9 @@ const Inventory = () => {
     setIsRowSelected(isRow);
   };
 
-  const reloadData = () => {
-    fetchDevices();
-    setTimeout(() => setHasModalSubmitted(true), 800);
+  const reloadData = async () => {
+    await fetchDevices();
+    setHasModalSubmitted(true);
   };
 
   return (

--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -50,6 +50,11 @@ const Inventory = () => {
     setIsRowSelected(isRow);
   };
 
+  const reloadData = () => {
+    fetchDevices();
+    setTimeout(() => setHasModalSubmitted(true), 800);
+  };
+
   return (
     <Fragment>
       <PageHeader className="pf-m-light">
@@ -106,7 +111,7 @@ const Inventory = () => {
             }}
             setUpdateModal={setUpdateModal}
             updateModal={updateModal}
-            refreshTable={fetchDevices}
+            refreshTable={reloadData}
           />
         </Suspense>
       )}
@@ -115,10 +120,7 @@ const Inventory = () => {
           isModalOpen={isAddDeviceModalOpen}
           setIsModalOpen={setIsAddDeviceModalOpen}
           setIsCreateGroupModalOpen={setIsCreateGroupModalOpen}
-          reloadData={() => {
-            fetchDevices();
-            setTimeout(() => setHasModalSubmitted(true), 800);
-          }}
+          reloadData={reloadData}
           deviceIds={isRowSelected ? deviceId : checkedDeviceIds}
         />
       )}
@@ -126,10 +128,7 @@ const Inventory = () => {
         <CreateGroupModal
           isModalOpen={isCreateGroupModalOpen}
           setIsModalOpen={setIsCreateGroupModalOpen}
-          reloadData={() => {
-            fetchDevices();
-            setTimeout(() => setHasModalSubmitted(true), 800);
-          }}
+          reloadData={reloadData}
           deviceIds={isRowSelected ? deviceId : checkedDeviceIds}
         />
       )}
@@ -137,10 +136,7 @@ const Inventory = () => {
         <RemoveDeviceModal
           isModalOpen={isRemoveDeviceModalOpen}
           setIsModalOpen={setIsRemoveDeviceModalOpen}
-          reloadData={() => {
-            fetchDevices();
-            setTimeout(() => setHasModalSubmitted(true), 800);
-          }}
+          reloadData={reloadData}
           deviceInfo={isRowSelected ? deviceId : checkedDeviceIds}
         />
       )}

--- a/src/Routes/Groups/GroupTable.js
+++ b/src/Routes/Groups/GroupTable.js
@@ -34,6 +34,8 @@ const GroupTable = ({
   handleCreateModal,
   handleRenameModal,
   handleDeleteModal,
+  hasModalSubmitted,
+  setHasModalSubmitted,
   fetchGroups,
 }) => {
   const [updateModal, setUpdateModal] = useState({
@@ -162,6 +164,8 @@ const GroupTable = ({
             click: handleCreateModal,
           },
         ]}
+        hasModalSubmitted={hasModalSubmitted}
+        setHasModalSubmitted={setHasModalSubmitted}
       />
       {updateModal.isOpen && (
         <Suspense
@@ -183,7 +187,10 @@ const GroupTable = ({
             }}
             setUpdateModal={setUpdateModal}
             updateModal={updateModal}
-            refreshTable={fetchGroups}
+            refreshTable={() => {
+              fetchGroups();
+              setTimeout(() => setHasModalSubmitted(true), 800);
+            }}
           />
         </Suspense>
       )}
@@ -200,6 +207,8 @@ GroupTable.propTypes = {
   handleRenameModal: PropTypes.func,
   handleDeleteModal: PropTypes.func,
   handleCreateModal: PropTypes.func,
+  hasModalSubmitted: PropTypes.bool,
+  setHasModalSubmitted: PropTypes.func,
   fetchGroups: PropTypes.func,
 };
 

--- a/src/Routes/Groups/GroupTable.js
+++ b/src/Routes/Groups/GroupTable.js
@@ -187,9 +187,9 @@ const GroupTable = ({
             }}
             setUpdateModal={setUpdateModal}
             updateModal={updateModal}
-            refreshTable={() => {
-              fetchGroups();
-              setTimeout(() => setHasModalSubmitted(true), 800);
+            refreshTable={async () => {
+              await fetchGroups();
+              setHasModalSubmitted(true);
             }}
           />
         </Suspense>

--- a/src/Routes/Groups/Groups.js
+++ b/src/Routes/Groups/Groups.js
@@ -27,6 +27,7 @@ const Groups = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [hasModalSubmitted, setHasModalSubmitted] = useState(false);
 
   const handleRenameModal = (id, name) => {
     setModalState({ id, name });
@@ -36,6 +37,11 @@ const Groups = () => {
   const handleDeleteModal = (id, name) => {
     setModalState({ id, name });
     setIsDeleteModalOpen(true);
+  };
+
+  const reloadData = () => {
+    fetchGroups();
+    setTimeout(() => setHasModalSubmitted(true), 800);
   };
 
   return (
@@ -53,6 +59,8 @@ const Groups = () => {
             handleRenameModal={handleRenameModal}
             handleDeleteModal={handleDeleteModal}
             handleCreateModal={() => setIsCreateModalOpen(true)}
+            hasModalSubmitted={hasModalSubmitted}
+            setHasModalSubmitted={setHasModalSubmitted}
             fetchGroups={fetchGroups}
           />
         ) : (
@@ -81,14 +89,14 @@ const Groups = () => {
         <CreateGroupModal
           isModalOpen={isCreateModalOpen}
           setIsModalOpen={setIsCreateModalOpen}
-          reloadData={fetchGroups}
+          reloadData={reloadData}
         />
       )}
       {isRenameModalOpen && (
         <RenameGroupModal
           isModalOpen={isRenameModalOpen}
           setIsModalOpen={setIsRenameModalOpen}
-          reloadData={fetchGroups}
+          reloadData={reloadData}
           modalState={modalState}
         />
       )}
@@ -96,7 +104,7 @@ const Groups = () => {
         <DeleteGroupModal
           isModalOpen={isDeleteModalOpen}
           setIsModalOpen={setIsDeleteModalOpen}
-          reloadData={fetchGroups}
+          reloadData={reloadData}
           modalState={modalState}
         />
       )}

--- a/src/Routes/Groups/Groups.js
+++ b/src/Routes/Groups/Groups.js
@@ -39,9 +39,9 @@ const Groups = () => {
     setIsDeleteModalOpen(true);
   };
 
-  const reloadData = () => {
-    fetchGroups();
-    setTimeout(() => setHasModalSubmitted(true), 800);
+  const reloadData = async () => {
+    await fetchGroups();
+    setHasModalSubmitted(true);
   };
 
   return (

--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -115,6 +115,8 @@ const ImageTable = ({
   fetchImageSets,
   openCreateWizard,
   openUpdateWizard,
+  hasModalSubmitted,
+  setHasModalSubmitted,
 }) => {
   const history = useHistory();
 
@@ -192,6 +194,8 @@ const ImageTable = ({
               click: () => openCreateWizard(),
             },
           ]}
+          hasModalSubmitted={hasModalSubmitted}
+          setHasModalSubmitted={setHasModalSubmitted}
         />
       )}
     </>
@@ -212,6 +216,8 @@ ImageTable.propTypes = {
     page: PropTypes.number,
     perPage: PropTypes.number,
   }),
+  hasModalSubmitted: PropTypes.bool,
+  setHasModalSubmitted: PropTypes.func,
 };
 
 export default ImageTable;

--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -37,6 +37,7 @@ const Images = () => {
     isOpen: false,
     imageId: null,
   });
+  const [hasModalSubmitted, setHasModalSubmitted] = useState(false);
 
   const openCreateWizard = () => {
     history.push({
@@ -57,6 +58,11 @@ const Images = () => {
     });
   };
 
+  const reload = () => {
+    fetchImageSets();
+    setTimeout(() => setHasModalSubmitted(true), 800);
+  };
+
   return (
     <Fragment>
       <PageHeader className="pf-m-light">
@@ -71,6 +77,8 @@ const Images = () => {
           fetchImageSets={fetchImageSets}
           openCreateWizard={openCreateWizard}
           openUpdateWizard={openUpdateWizard}
+          hasModalSubmitted={hasModalSubmitted}
+          setHasModalSubmitted={setHasModalSubmitted}
         />
       </Main>
       {isCreateWizardOpen && (
@@ -89,7 +97,7 @@ const Images = () => {
               });
               setIsCreateWizardOpen(false);
             }}
-            reload={fetchImageSets}
+            reload={reload}
           />
         </Suspense>
       )}
@@ -114,7 +122,7 @@ const Images = () => {
                 };
               });
             }}
-            reload={fetchImageSets}
+            reload={reload}
             updateImageID={UpdateWizard.imageId}
           />
         </Suspense>

--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -58,9 +58,9 @@ const Images = () => {
     });
   };
 
-  const reload = () => {
-    fetchImageSets();
-    setTimeout(() => setHasModalSubmitted(true), 800);
+  const reload = async () => {
+    await fetchImageSets();
+    setHasModalSubmitted(true);
   };
 
   return (

--- a/src/Routes/Repositories/Repositories.js
+++ b/src/Routes/Repositories/Repositories.js
@@ -32,6 +32,7 @@ const Repository = () => {
     name: '',
     baseURL: '',
   });
+  const [hasModalSubmitted, setHasModalSubmitted] = useState(false);
 
   const closeModal = ({ type, id = null, name = '', baseURL = '' }) => {
     setModalDetails((prevState) => ({
@@ -44,6 +45,11 @@ const Repository = () => {
         [type]: !prevState.isOpen[type],
       },
     }));
+  };
+
+  const reloadData = () => {
+    fetchRepos();
+    setTimeout(() => setHasModalSubmitted(true), 800);
   };
 
   return (
@@ -59,6 +65,8 @@ const Repository = () => {
               isLoading={isLoading}
               hasError={hasError}
               fetchRepos={fetchRepos}
+              hasModalSubmitted={hasModalSubmitted}
+              setHasModalSubmitted={setHasModalSubmitted}
             />
           ) : (
             <EmptyState
@@ -75,7 +83,7 @@ const Repository = () => {
         <AddModal
           isOpen={modalDetails.isOpen.add}
           closeModal={closeModal}
-          reloadData={fetchRepos}
+          reloadData={reloadData}
         />
         <EditModal
           isOpen={modalDetails.isOpen.edit}
@@ -83,7 +91,7 @@ const Repository = () => {
           name={modalDetails.name}
           baseURL={modalDetails.baseURL}
           closeModal={closeModal}
-          reloadData={fetchRepos}
+          reloadData={reloadData}
         />
         <RemoveModal
           isOpen={modalDetails.isOpen.remove}
@@ -91,7 +99,7 @@ const Repository = () => {
           name={modalDetails.name}
           baseURL={modalDetails.baseURL}
           closeModal={closeModal}
-          reloadData={fetchRepos}
+          reloadData={reloadData}
         />
       </Main>
     </>

--- a/src/Routes/Repositories/Repositories.js
+++ b/src/Routes/Repositories/Repositories.js
@@ -47,9 +47,9 @@ const Repository = () => {
     }));
   };
 
-  const reloadData = () => {
-    fetchRepos();
-    setTimeout(() => setHasModalSubmitted(true), 800);
+  const reloadData = async () => {
+    await fetchRepos();
+    setHasModalSubmitted(true);
   };
 
   return (

--- a/src/components/general-table/GeneralTable.js
+++ b/src/components/general-table/GeneralTable.js
@@ -120,7 +120,7 @@ const GeneralTable = ({
       : apiFilterSort
       ? loadTableData(dispatch, query)
       : null;
-  }, [chipsArray, perPage, page, sortBy]);
+  }, [chipsArray, perPage, page, sortBy, hasModalSubmitted]);
 
   useEffect(() => {
     setCheckedRows(defaultCheckedRows);


### PR DESCRIPTION
# Description

After submitting a modal (add to group, remove from group, or update) from the Systems page, the refreshed table is sorted by name instead of by "Last seen", which is the default. Also, the "Last seen" column header is still highlighted, as if the table is still sorted by that column.

Similar behavior can be seen on the Groups, Repositories, and Images pages too.

This PR fixes this issue by setting `hasModalSubmitted` when modals have submitted, and re-running the relevant query w/ the correct sort and pagination query params in `GeneralTable` when this state variable has changed.

Fixes # THEEDGE-2541

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted