### PR TITLE
Refresh system detail page after editing display name or Ansible hostname

### DIFF
--- a/src/components/DeviceDetail.js
+++ b/src/components/DeviceDetail.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useState } from 'react';
 import { useStore, useSelector } from 'react-redux';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Tooltip } from '@patternfly/react-core';
@@ -65,6 +65,9 @@ const InfrastructureCard = (props) => (
 const ImageInformationCard = lazy(() => import('./ImageInformationCard'));
 
 const GeneralInformationTab = () => {
+  const [displayName, setDisplayName] = useState('');
+  const [ansibleHost, setAnsibleHost] = useState('');
+
   const [{ statusHelper }] = useLoadModule(
     { appName: 'inventory', scope: 'inventory', module: './dataMapper' },
     {}
@@ -109,6 +112,12 @@ const GeneralInformationTab = () => {
                   value: <GreenbootStatus status={greenbootStatus} />,
                 },
               ]}
+              setDisplayName={(id, value) =>
+                displayName !== value && setDisplayName(value)
+              }
+              setAnsibleHost={(id, value) =>
+                ansibleHost !== value && setAnsibleHost(value)
+              }
             />
           </Suspense>
         )}


### PR DESCRIPTION
# Description

When editing a system's `Display name` or `Ansible hostname` in the system details page, the new values don't display until the user performs a manual refresh. This PR fixes the issue.

Fixes # THEEDGE-2274

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted