### PR TITLE
Fix table sorting after modal submit for custom repositories

### DIFF
--- a/src/Routes/Repositories/RepositoryTable.js
+++ b/src/Routes/Repositories/RepositoryTable.js
@@ -14,6 +14,8 @@ const RepositoryTable = ({
   hasError,
   fetchRepos,
   closeModal,
+  hasModalSubmitted,
+  setHasModalSubmitted,
 }) => {
   const actionResolver = (rowData) => {
     if (!rowData.rowInfo) {
@@ -99,6 +101,8 @@ const RepositoryTable = ({
             click: () => closeModal({ type: 'add' }),
           },
         ]}
+        hasModalSubmitted={hasModalSubmitted}
+        setHasModalSubmitted={setHasModalSubmitted}
       />
     </>
   );
@@ -108,8 +112,10 @@ RepositoryTable.propTypes = {
   count: PropTypes.number,
   isLoading: PropTypes.bool,
   hasError: PropTypes.bool,
-  closeModal: PropTypes.func,
   fetchRepos: PropTypes.func,
+  closeModal: PropTypes.func,
+  hasModalSubmitted: PropTypes.bool,
+  setHasModalSubmitted: PropTypes.func,
 };
 
 export default RepositoryTable;


### PR DESCRIPTION
# Description

This PR includes the fix for custom repositories that was left out of https://github.com/RedHatInsights/edge-frontend/pull/537

The table on the Repositories page should now be correctly sorted, paginated, and filtered after adding, editing, or removing a custom repository.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted