### PR TITLE
Include API error msg in notification dispatched by apiWithToast

### DIFF
--- a/src/utils/apiWithToast.js
+++ b/src/utils/apiWithToast.js
@@ -33,6 +33,10 @@ const apiWithToast = (dispatch, api, statusMessages) => {
         ...addNotification({
           variant: 'danger',
           ...statusMessages.onError,
+          // Add error message from API, if present
+          description: err?.Title
+            ? `${statusMessages.onError.description}: ${err.Title}`
+            : statusMessages.onError.description,
         }),
       });
       return err;


### PR DESCRIPTION
# Description

When API actions submitted via `apiWithToast` fail, the error messages are generic and uninformative, e.g.,:

- `Failed to create a repo`
- `Failed to remove a repository`

This PR adds the error message string returned by the API, to provide more helpful info to the user:

- `Failed to create a repo: custom repository already exists`
- `Failed to remove a repository: custom repository is used by some images`


Fixes # THEEDGE-2422

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted