### PR TITLE
THEEDGE-2589 Added new status and retry popover on device details

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -107,3 +107,7 @@ a#build-register-images, a#working-with-systems {
 .pfext-quick-start-tile-header__status .pf-m-outline {
   display: none;
 }
+
+.pf-c-description-list__group .pf-c-description-list__term {
+  width: fit-content
+}

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -38,9 +38,6 @@ const DeviceDetail = () => {
   const { getRegistry } = useContext(RegistryContext);
   const { deviceId } = useParams();
   const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
-  const groupName = useSelector(
-    ({ groupsDetailReducer }) => groupsDetailReducer?.name
-  );
 
   const [imageData, setImageData] = useState();
   const [updateModal, setUpdateModal] = useState({
@@ -115,19 +112,8 @@ const DeviceDetail = () => {
         <PageHeader>
           <Breadcrumb ouiaId="systems-list">
             <BreadcrumbItem>
-              <Link to={deviceId ? `/groups` : '/inventory'}>
-                {deviceId ? 'Groups' : 'Systems'}
-              </Link>
+              <Link to="/inventory">Systems</Link>
             </BreadcrumbItem>
-            {deviceId && (
-              <BreadcrumbItem>
-                {groupName ? (
-                  <Link to={`/groups/${deviceId}`}>{groupName}</Link>
-                ) : (
-                  <Skeleton size={SkeletonSize.xs} />
-                )}
-              </BreadcrumbItem>
-            )}
             <BreadcrumbItem isActive>
               <div className="ins-c-inventory__detail--breadcrumb-name">
                 {entity?.display_name || <Skeleton size={SkeletonSize.xs} />}

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -22,8 +22,10 @@ import { deviceDetail } from '../../store/deviceDetail';
 import { RegistryContext } from '../../store';
 import systemProfileStore from '@redhat-cloud-services/frontend-components-inventory-general-info/redux';
 import DeviceDetailTabs from './DeviceDetailTabs';
-import { getDeviceHasUpdate } from '../../api/devices';
-import Status from '../../components/Status';
+import { getDeviceHasUpdate, getInventory } from '../../api/devices';
+import Status, { getDeviceStatus } from '../../components/Status';
+import useApi from '../../hooks/useApi';
+import RetryUpdatePopover from '../Devices/RetryUpdatePopover';
 
 const UpdateDeviceModal = React.lazy(() =>
   import(
@@ -34,13 +36,10 @@ const UpdateDeviceModal = React.lazy(() =>
 const DeviceDetail = () => {
   const [imageId, setImageId] = useState(null);
   const { getRegistry } = useContext(RegistryContext);
-  const { inventoryId, uuid } = useParams();
+  const { deviceId } = useParams();
   const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
   const groupName = useSelector(
     ({ groupsDetailReducer }) => groupsDetailReducer?.name
-  );
-  const deviceId = useSelector(
-    ({ entityDetails }) => entityDetails?.entity?.id
   );
 
   const [imageData, setImageData] = useState();
@@ -78,9 +77,28 @@ const DeviceDetail = () => {
     })();
   }, [entity, reload]);
 
-  useEffect(() => {
-    insights?.chrome?.appObjectId?.(inventoryId);
-  }, [inventoryId]);
+  const [deviceData, fetchDeviceData] = useApi({
+    api: () =>
+      getInventory({
+        query: {
+          uuid: deviceId,
+        },
+      }),
+  });
+
+  const [deviceView] = deviceData.data?.data?.devices || [];
+  const {
+    Status: deviceViewStatus,
+    UpdateAvailable: updateAvailable,
+    DispatcherStatus: updateStatus,
+    LastSeen: lastSeen,
+  } = deviceView || {};
+
+  const deviceStatus = getDeviceStatus(
+    deviceViewStatus,
+    updateAvailable,
+    updateStatus
+  );
 
   return (
     <>
@@ -97,14 +115,14 @@ const DeviceDetail = () => {
         <PageHeader>
           <Breadcrumb ouiaId="systems-list">
             <BreadcrumbItem>
-              <Link to={uuid ? `/groups` : '/inventory'}>
-                {uuid ? 'Groups' : 'Systems'}
+              <Link to={deviceId ? `/groups` : '/inventory'}>
+                {deviceId ? 'Groups' : 'Systems'}
               </Link>
             </BreadcrumbItem>
-            {uuid && (
+            {deviceId && (
               <BreadcrumbItem>
                 {groupName ? (
-                  <Link to={`/groups/${uuid}`}>{groupName}</Link>
+                  <Link to={`/groups/${deviceId}`}>{groupName}</Link>
                 ) : (
                   <Skeleton size={SkeletonSize.xs} />
                 )}
@@ -144,21 +162,27 @@ const DeviceDetail = () => {
 
           {isDeviceStatusLoading ? (
             <Skeleton size={SkeletonSize.xs} />
-          ) : imageData?.UpdateTransactions[
-              imageData?.UpdateTransactions?.length - 1
-            ]?.Status === 'BUILDING' ||
-            imageData?.UpdateTransactions[
-              imageData?.UpdateTransactions?.length - 1
-            ]?.Status === 'CREATED' ? (
-            <Status type="updating" isLabel={true} className="pf-u-mt-sm" />
-          ) : imageData?.Device?.UpdateAvailable ? (
-            <Status
-              type="updateAvailable"
-              isLabel={true}
-              className="pf-u-mt-sm"
-            />
+          ) : deviceStatus === 'error' || deviceStatus === 'unresponsive' ? (
+            <RetryUpdatePopover
+              lastSeen={lastSeen}
+              deviceUUID={deviceId}
+              device={deviceView}
+              position={'right'}
+              fetchDevices={fetchDeviceData}
+            >
+              <Status
+                type={
+                  deviceStatus === 'error'
+                    ? 'errorWithExclamationCircle'
+                    : deviceStatus
+                }
+                isLink={true}
+                isLabel={true}
+                className="pf-u-mt-sm cursor-pointer"
+              />
+            </RetryUpdatePopover>
           ) : (
-            <Status type="running" isLabel={true} className="pf-u-mt-sm" />
+            <Status type={deviceStatus} isLabel={true} className="pf-u-mt-sm" />
           )}
         </PageHeader>
         <Grid gutter="md">

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -9,19 +9,8 @@ import { Tooltip } from '@patternfly/react-core';
 import CustomEmptyState from '../../components/Empty';
 import { useHistory } from 'react-router-dom';
 import { emptyStateNoFliters } from '../../utils';
-import DeviceStatus from '../../components/Status';
+import DeviceStatus, { getDeviceStatus } from '../../components/Status';
 import RetryUpdatePopover from './RetryUpdatePopover';
-
-const getDeviceStatus = (deviceStatus, isUpdateAvailable, dispatcherStatus) =>
-  dispatcherStatus === 'ERROR'
-    ? 'error'
-    : dispatcherStatus === 'UNRESPONSIVE'
-    ? 'unresponsive'
-    : deviceStatus === 'UPDATING'
-    ? 'updating'
-    : isUpdateAvailable
-    ? 'updateAvailable'
-    : 'upToDate';
 
 const defaultFilters = [
   {

--- a/src/Routes/Devices/RetryUpdatePopover.js
+++ b/src/Routes/Devices/RetryUpdatePopover.js
@@ -116,6 +116,7 @@ const RetryUpdatePopover = (props) => {
           icon="true"
           varient="icon"
           color="red"
+          position={props.position ? props.position : 'left'}
           headerComponent="h6"
           bodyContent={getDevicePopoverDescription(props)}
           footerContent={
@@ -160,5 +161,6 @@ RetryUpdatePopover.propTypes = {
   children: PropTypes.object,
   device: PropTypes.object,
   DeviceUUID: PropTypes.string,
+  position: PropTypes.string,
   fetchDevices: PropTypes.func,
 };

--- a/src/components/Status.js
+++ b/src/components/Status.js
@@ -3,6 +3,21 @@ import PropTypes from 'prop-types';
 import { Label, Tooltip, Split, SplitItem } from '@patternfly/react-core';
 import { statusMapper } from '../constants/status';
 
+export const getDeviceStatus = (
+  deviceStatus,
+  isUpdateAvailable,
+  dispatcherStatus
+) =>
+  dispatcherStatus === 'ERROR'
+    ? 'error'
+    : dispatcherStatus === 'UNRESPONSIVE'
+    ? 'unresponsive'
+    : deviceStatus === 'UPDATING'
+    ? 'updating'
+    : isUpdateAvailable
+    ? 'updateAvailable'
+    : 'upToDate';
+
 const Status = ({
   type,
   isLabel = false,


### PR DESCRIPTION
# Description

- Added new status and retry popover on device details.
- Added new props on the popover component to change the position.
- Refactored `getDevicesStatus` for reuse and maintainability.

Fixes # [(THEEDGE-2589)](https://issues.redhat.com/browse/THEEDGE-2589)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted