### PR TITLE
Remove invalid hasIcon prop from HelperText components

### DIFF
--- a/src/Routes/Repositories/modals/EditModal.js
+++ b/src/Routes/Repositories/modals/EditModal.js
@@ -43,7 +43,7 @@ const EditModal = ({ closeModal, isOpen, id, name, baseURL, reloadData }) => {
         label: 'BaseURL',
         placeholder: 'https://',
         helperText: (
-          <HelperText hasIcon>
+          <HelperText>
             <HelperTextItem className="pf-u-pb-md" variant="warning" hasIcon>
               If you change the repo URL, you may not have access to the
               packages that were used to build images that reference this

--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 
 const WarningInstallerHelperText = () => (
-  <HelperText className="pf-u-ml-lg" hasIcon>
+  <HelperText className="pf-u-ml-lg">
     <HelperTextItem className="pf-u-pb-md" variant="warning" hasIcon>
       Creating an installable version of your image increases the build time and
       is not needed for updating existing systems. <br />


### PR DESCRIPTION
# Description

In the `Edit Repository` modal and in the `Update Image` wizard's `Options` step, there are `HelperTextItem` components that use the `hasIcon` prop. The parent `HelperText` components were also passed `hasIcon`, but this is not a valid prop for `HelperText`. React complains about it:

```
Warning: React does not recognize the `hasIcon` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `hasicon` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

This PR removes these invalid props.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted