### PR TITLE
Fix breadcrumbs in GroupsDetail

### DIFF
--- a/src/Routes/GroupsDetail/GroupsDetail.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.js
@@ -147,8 +147,10 @@ const GroupsDetail = () => {
             <BreadcrumbItem>{groupName}</BreadcrumbItem>
           </Breadcrumb>
         ) : (
-          <Breadcrumb isActive>
-            <Skeleton width="100px" />
+          <Breadcrumb>
+            <BreadcrumbItem isActive>
+              <Skeleton width="100px" />
+            </BreadcrumbItem>
           </Breadcrumb>
         )}
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>


### PR DESCRIPTION
# Description

This PR fixes a few props usage warnings that occur when viewing a group's details page:

```
Warning: React does not recognize the `showDivider` prop on a DOM element

div
Skeleton@https://stage.foo.redhat.com:1337/beta/apps/edge/js/vendors-node_modules_patternfly_react-core_dist_esm_components_Alert_Alert_js-node_modules_pa-6dd02d.js:5439:75
ol
nav
Breadcrumb@https://stage.foo.redhat.com:1337/beta/apps/edge/js/vendors-node_modules_patternfly_react-core_dist_esm_components_Breadcrumb_Breadcrumb_js-node_-d8227f.js:26:112
section
PageHeader@https://stage.foo.redhat.com:1337/beta/apps/edge/js/vendors-node_modules_data-driven-forms_pf4-component-mapper_esm_component-mapper_index_js-nod-00bc01.js:10417:19
GroupsDetail@https://stage.foo.redhat.com:1337/beta/apps/edge/js/GroupsDetailPage.js:3008:75
[...]
```

and:

```
Warning: React does not recognize the `isActive` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isactive` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
nav
Breadcrumb@https://stage.foo.redhat.com:1337/beta/apps/edge/js/vendors-node_modules_patternfly_react-core_dist_esm_components_Breadcrumb_Breadcrumb_js-node_-d8227f.js:26:112
section
PageHeader@https://stage.foo.redhat.com:1337/beta/apps/edge/js/vendors-node_modules_data-driven-forms_pf4-component-mapper_esm_component-mapper_index_js-nod-00bc01.js:10417:19
GroupsDetail@https://stage.foo.redhat.com:1337/beta/apps/edge/js/GroupsDetailPage.js:3008:75
[...]
```

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted