### PR TITLE
RetryUpdatePopover fixes

### DIFF
--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -151,7 +151,6 @@ const DeviceDetail = () => {
           ) : deviceStatus === 'error' || deviceStatus === 'unresponsive' ? (
             <RetryUpdatePopover
               lastSeen={lastSeen}
-              deviceUUID={deviceId}
               device={deviceView}
               position={'right'}
               fetchDevices={fetchDeviceData}

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -163,16 +163,15 @@ const createRows = (devices, hasLinks, fetchDevices) => {
         },
         {
           title:
-            deviceStatus == 'error' || deviceStatus == 'unresponsive' ? (
+            deviceStatus === 'error' || deviceStatus === 'unresponsive' ? (
               <RetryUpdatePopover
                 lastSeen={LastSeen}
-                deviceUUID={DeviceUUID}
                 fetchDevices={fetchDevices}
                 device={device}
               >
                 <DeviceStatus
                   type={
-                    deviceStatus == 'error'
+                    deviceStatus === 'error'
                       ? 'errorWithExclamationCircle'
                       : deviceStatus
                   }
@@ -182,7 +181,7 @@ const createRows = (devices, hasLinks, fetchDevices) => {
             ) : (
               <DeviceStatus
                 type={
-                  deviceStatus == 'error'
+                  deviceStatus === 'error'
                     ? 'errorWithExclamationCircle'
                     : deviceStatus
                 }


### PR DESCRIPTION
# Description

This PR fixes a few issues with the `RetryUpdatePopover` component:
- Some of the conditional logic in `DeviceTable` used `==` instead of `===`.
- The `DeviceUUID` and `deviceUUID` props in `RetryUpdatePopover.propTypes` are redundant and unnecessary.
- The prop type for `children` should be `element`.
- Removed duplicate code when returning the title and description for the popover.
- Removed debugging code and unused code.
- Explicitly listed props in function definitions.
- Fixed an attribute typo (`variant` instead of `varient`).

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted