### PR TITLE
Fixed device update button inconsistency

### DIFF
--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -126,12 +126,8 @@ const DeviceDetail = () => {
               {
                 title: 'Update',
                 isDisabled:
-                  imageData?.UpdateTransactions?.[
-                    imageData?.UpdateTransactions.length - 1
-                  ]?.Status === 'BUILDING' ||
-                  imageData?.UpdateTransactions?.[
-                    imageData?.UpdateTransactions.length - 1
-                  ]?.Status === 'CREATED' ||
+                  imageData?.UpdateTransactions?.[0]?.Status === 'BUILDING' ||
+                  imageData?.UpdateTransactions?.[0]?.Status === 'CREATED' ||
                   !imageData?.ImageInfo?.UpdatesAvailable?.length > 0 ||
                   !updateModal.imageSetId,
                 onClick: () => {

--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -23,10 +23,8 @@ const getActiveAlert = (
     return 'noAlert';
   }
   if (
-    deviceData?.UpdateTransactions[deviceData?.UpdateTransactions?.length - 1]
-      ?.Status === 'BUILDING' ||
-    deviceData?.UpdateTransactions[deviceData?.UpdateTransactions?.length - 1]
-      ?.Status === 'CREATED'
+    deviceData?.UpdateTransactions[0]?.Status === 'BUILDING' ||
+    deviceData?.UpdateTransactions[0]?.Status === 'CREATED'
   ) {
     return 'systemUpdating';
   }

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -293,7 +293,9 @@ const DeviceTable = ({
   };
 
   const areActionsDisabled = (rowData) =>
-    rowData.rowInfo?.deviceStatus !== 'updateAvailable';
+    !rowData.rowInfo?.UpdateAvailable &&
+    (rowData.rowInfo?.deviceStatus === 'updating' ||
+      rowData.rowInfo?.deviceStatus === 'upToDate');
 
   return (
     <>


### PR DESCRIPTION
# Description

API is returning the update transactions list reversed, which caused a inconsistency in the device update button.
This PR fixes this issue.

I checked and now all the pages are consistent.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted