### PR TITLE
Add id to DeviceTable toolbar components

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -352,6 +352,7 @@ const DeviceTable = ({
                   {
                     isDisabled: !selectedItemsUpdateable,
                     title: 'Update',
+                    id: 'toolbar-update-button',
                     click: () => handleUpdateSelected(),
                   },
                 ]

--- a/src/components/general-table/ToolbarHeader.js
+++ b/src/components/general-table/ToolbarHeader.js
@@ -15,9 +15,9 @@ import FilterChip from './FilterChips';
 import ToolbarKebab from './ToolbarKebab';
 
 const ToolbarButtons = ({ buttons }) => {
-  return buttons.map(({ title, click, isDisabled }, index) => (
+  return buttons.map(({ title, click, isDisabled, id }, index) => (
     <ToolbarItem key={index}>
-      <Button onClick={click} variant="primary" isDisabled={isDisabled}>
+      <Button onClick={click} variant="primary" isDisabled={isDisabled} id={id}>
         {title}
       </Button>
     </ToolbarItem>


### PR DESCRIPTION
# Description

Added new attribute 'id' to identify DeviceTable toolbar components.

Fixes: IQE CI test failures

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted