### PR TITLE
Fix prop name in Custom Packages image wizard step

### DIFF
--- a/src/Routes/ImageManager/steps/customPackage.js
+++ b/src/Routes/ImageManager/steps/customPackage.js
@@ -134,7 +134,7 @@ export default {
       name: 'warning',
       label: (
         <Text className="pf-u-warning-color-200">
-          <ExclamationTriangleIcon class="pf-u-warning-color-100" />
+          <ExclamationTriangleIcon className="pf-u-warning-color-100" />
           &nbsp; Packages names that do not have exact name and casing will not
           be included in the image.
         </Text>


### PR DESCRIPTION
# Description

This PR fixes an invalid prop name in the Image wizard's Custom Packages step, which was causing browser console tracebacks like the following:

```
Warning: Invalid DOM property `class`. Did you mean `className`?
svg
p@https://console.stage.redhat.com/beta/apps/edge/js/674.1665520590743.525dbc8cf6bcee61a9b5.js:2:162213
p
c@https://console.stage.redhat.com/beta/apps/edge/js/36.1665520590743.525dbc8cf6bcee61a9b5.js:1:134436
div
o@https://console.stage.redhat.com/beta/apps/edge/js/36.1665520590743.525dbc8cf6bcee61a9b5.js:1:134860
[...]
```

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted