### PR TITLE
Fix conditional display of Alert by device status in UpdateDeviceModal

### DIFF
--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -52,28 +52,6 @@ const DeviceDetail = () => {
     insights.chrome.appAction('system-detail');
   }, []);
 
-  useEffect(() => {
-    (async () => {
-      if (!entity?.display_name) {
-        return;
-      }
-      const image_data = await getDeviceHasUpdate(deviceId);
-      setImageData(image_data);
-      setIsDeviceStatusLoading(false);
-      setUpdateModal((prevState) => ({
-        ...prevState,
-        deviceData: [
-          {
-            display_name: entity.display_name,
-            id: entity.id,
-          },
-        ],
-        imageSetId: image_data?.ImageInfo?.Image?.ImageSetID,
-      }));
-      setImageId(image_data?.ImageInfo?.Image?.ID);
-    })();
-  }, [entity, reload]);
-
   const [deviceData, fetchDeviceData] = useApi({
     api: () =>
       getInventory({
@@ -96,6 +74,29 @@ const DeviceDetail = () => {
     updateAvailable,
     updateStatus
   );
+
+  useEffect(() => {
+    (async () => {
+      if (!entity?.display_name) {
+        return;
+      }
+      const image_data = await getDeviceHasUpdate(deviceId);
+      setImageData(image_data);
+      setIsDeviceStatusLoading(false);
+      setUpdateModal((prevState) => ({
+        ...prevState,
+        deviceData: [
+          {
+            display_name: entity.display_name,
+            id: entity.id,
+            deviceStatus: deviceStatus,
+          },
+        ],
+        imageSetId: image_data?.ImageInfo?.Image?.ImageSetID,
+      }));
+      setImageId(image_data?.ImageInfo?.Image?.ID);
+    })();
+  }, [entity, reload]);
 
   return (
     <>

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -271,6 +271,7 @@ const DeviceTable = ({
                 {
                   id: rowData.rowInfo.id,
                   display_name: rowData.rowInfo.display_name,
+                  deviceStatus: rowData.rowInfo.deviceStatus,
                 },
               ],
               imageSetId: rowData.rowInfo.imageSetId,


### PR DESCRIPTION
# Description

If `UpdateDeviceModal` is displayed by clicking on either the row-level kebab on the Inventory page or on the system details Actions dropdown, then the alert `Some systems will not be updated. [...]` is always displayed. This happens because the system's status isn't sent to the modal from those dropdowns. Currently, the system statuses are only sent when using the Inventory page's toolbar Update button. This PR fixes the issue by sending the device status to the modal from those other actions as well. (The Alert can still be displayed if the system has a status of `Unresponsive`.)

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted