### PR TITLE
Add files for frontend migration

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="edge"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/edge-frontend"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+#16 is the default Node version. Change this to override it.
+export NODE_BUILD_VERSION=16
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# Stubbed out for now
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS

--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: edge-frontend
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: Frontend
+    metadata:
+      name: edge
+    spec:
+      envName: ${ENV_NAME}
+      title: Edge
+      deploymentRepo: https://github.com/RedHatInsights/edge-frontend
+      API:
+        versions:
+          - v1
+      frontend:
+        paths:
+          - /apps/edge
+      image: ${IMAGE}:${IMAGE_TAG}
+      navItems:
+        - title: Inventory
+          expandable: true
+          routes:
+            - title: Groups
+              appId: edge
+              filterable: false
+              href: /edge/fleet-management
+              permissions:
+                - method: withEmail
+                  args:
+                    - "@redhat.com"
+                    - "@sbb.ch"
+            - title: Systems
+              appId: edge
+              filterable: false
+              href: /edge/inventory
+              permissions:
+                - method: withEmail
+                  args:
+                    - "@redhat.com"
+                    - "@sbb.ch"
+          permissions:
+            - method: withEmail
+              args:
+                - "@redhat.com"
+                - "@sbb.ch"
+      module:
+        manifestLocation: /apps/edge/fed-mods.json
+        modules:
+          - id: edge
+            module: ./RootApp
+            routes:
+              - pathname: /edge
+        moduleID: edge
+parameters:
+  - name: ENV_NAME
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE
+    value: quay.io/cloudservices/edge-frontend

--- a/package.json
+++ b/package.json
@@ -1,129 +1,130 @@
 {
-  "name": "insights-frontend-starter-app",
-  "version": "1.1.0",
-  "private": false,
-  "scripts": {
-    "build": "webpack --config config/prod.webpack.config.js",
-    "build:prod": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
-    "deploy": "npm-run-all build:prod lint test",
-    "lint": "npm-run-all lint:*",
-    "lint:js": "eslint config src",
-    "lint:js:fix": "eslint config src --fix",
-    "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
-    "nightly": "npm run deploy",
-    "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",
-    "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
-    "start:proxy": "PROXY=true NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
-    "start:federated": "BETA=true fec static --config config/dev.webpack.config.js",
-    "test": "jest --verbose",
-    "verify": "npm-run-all build lint test",
-    "prepare": "husky install"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-      "src/**/*.js",
-      "!src/**/stories/*"
-    ],
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(@data-driven-forms/|@patternfly/|@redhat-cloud-services)).*$"
-    ],
-    "coverageDirectory": "./coverage/",
-    "moduleNameMapper": {
-      "\\.(css|scss)$": "identity-obj-proxy"
+    "name": "insights-frontend-starter-app",
+    "version": "1.1.0",
+    "private": false,
+    "scripts": {
+        "build": "webpack --config config/prod.webpack.config.js",
+        "build:prod": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
+        "deploy": "npm-run-all build:prod lint test",
+        "lint": "npm-run-all lint:*",
+        "lint:js": "eslint config src",
+        "lint:js:fix": "eslint config src --fix",
+        "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
+        "nightly": "npm run deploy",
+        "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",
+        "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
+        "start:proxy": "PROXY=true NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
+        "start:federated": "BETA=true fec static --config config/dev.webpack.config.js",
+        "test": "jest --verbose",
+        "verify": "npm-run-all build lint test",
+        "prepare": "husky install"
     },
-    "roots": [
-      "<rootDir>/src/"
+    "jest": {
+        "collectCoverage": true,
+        "collectCoverageFrom": [
+            "src/**/*.js",
+            "!src/**/stories/*"
+        ],
+        "transformIgnorePatterns": [
+            "<rootDir>/node_modules/(?!(@data-driven-forms/|@patternfly/|@redhat-cloud-services)).*$"
+        ],
+        "coverageDirectory": "./coverage/",
+        "moduleNameMapper": {
+            "\\.(css|scss)$": "identity-obj-proxy"
+        },
+        "roots": [
+            "<rootDir>/src/"
+        ],
+        "setupFiles": [
+            "<rootDir>/config/setupTests.js"
+        ],
+        "testEnvironment": "jsdom",
+        "test": "TZ=UTC jest --verbose --no-cache"
+    },
+    "transformIgnorePatterns": [
+        "/node_modules/(?!@redhat-cloud-services)"
     ],
-    "setupFiles": [
-      "<rootDir>/config/setupTests.js"
-    ],
-    "testEnvironment": "jsdom"
-  },
-  "transformIgnorePatterns": [
-    "/node_modules/(?!@redhat-cloud-services)"
-  ],
-  "dependencies": {
-    "@babel/runtime": "7.15.4",
-    "@data-driven-forms/common": "^3.18.11",
-    "@data-driven-forms/pf4-component-mapper": "^3.18.11",
-    "@data-driven-forms/react-form-renderer": "^3.18.11",
-    "@patternfly/patternfly": "4.132.2",
-    "@patternfly/quickstarts": "^2.3.1",
-    "@patternfly/react-charts": "^6.92.0",
-    "@patternfly/react-core": "4.175.4",
-    "@patternfly/react-icons": "^4.90.0",
-    "@patternfly/react-styles": "^4.89.0",
-    "@patternfly/react-table": "4.29.58",
-    "@patternfly/react-tokens": "^4.91.0",
-    "@redhat-cloud-services/frontend-components": "3.4.1",
-    "@redhat-cloud-services/frontend-components-inventory-general-info": "^3.4.0",
-    "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
-    "@redhat-cloud-services/frontend-components-utilities": "3.2.3",
-    "@redhat-cloud-services/host-inventory-client": "^1.0.111",
-    "@unleash/proxy-client-react": "^1.0.4",
-    "babel-plugin-transform-imports": "^2.0.0",
-    "chai-sorted": "^0.2.0",
-    "classnames": "2.3.1",
-    "lodash": "^4.17.21",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-redux": "7.2.5",
-    "react-router-dom": "5.3.0",
-    "redux": "4.1.1",
-    "redux-logger": "3.0.6",
-    "redux-promise-middleware": "6.1.2",
-    "sass-loader": "^12.6.0"
-  },
-  "devDependencies": {
-    "@babel/core": "7.15.5",
-    "@babel/plugin-proposal-object-rest-spread": "7.15.6",
-    "@babel/plugin-syntax-dynamic-import": "7.8.3",
-    "@babel/plugin-transform-runtime": "7.15.0",
-    "@babel/preset-env": "7.15.6",
-    "@babel/preset-flow": "7.14.5",
-    "@babel/preset-react": "7.14.5",
-    "@cypress/code-coverage": "^3.10.0",
-    "@redhat-cloud-services/eslint-config-redhat-cloud-services": "1.2.1",
-    "@redhat-cloud-services/frontend-components-config": "4.6.18",
-    "@testing-library/react": "^12.1.5",
-    "@webpack-cli/serve": "^1.6.1",
-    "babel-core": "7.0.0-bridge.0",
-    "babel-eslint": "10.1.0",
-    "babel-jest": "27.2.0",
-    "babel-plugin-dual-import": "1.2.1",
-    "babel-plugin-lodash": "3.3.4",
-    "cross-fetch": "^3.1.5",
-    "css-loader": "6.2.0",
-    "cypress": "^10.9.0",
-    "eslint": "7.32.0",
-    "eslint-config-prettier": "8.3.0",
-    "eslint-loader": "4.0.2",
-    "eslint-plugin-react": "7.25.1",
-    "eslint-plugin-react-hooks": "4.2.0",
-    "husky": "^7.0.0",
-    "identity-obj-proxy": "3.0.0",
-    "jest": "^27.5.1",
-    "jest-fetch-mock": "^3.0.3",
-    "node-sass": "7.0.1",
-    "npm-run-all": "4.1.5",
-    "postcss": "8.3.6",
-    "prop-types": "15.7.2",
-    "redux-mock-store": "^1.5.4",
-    "sass": "^1.55.0",
-    "stylelint": "13.13.1",
-    "stylelint-config-recommended-scss": "4.3.0",
-    "stylelint-scss": "3.21.0",
-    "webpack": "5.57.1",
-    "webpack-bundle-analyzer": "^4.6.1",
-    "webpack-cli": "4.9.1",
-    "webpack-dev-server": "^4.6.0"
-  },
-  "engines": {
-    "node": ">=16.13.0 <= 16.13.1",
-    "npm": ">=7.0.0"
-  },
-  "insights": {
-    "appname": "edge"
-  }
+    "dependencies": {
+        "@babel/runtime": "7.15.4",
+        "@data-driven-forms/common": "^3.18.11",
+        "@data-driven-forms/pf4-component-mapper": "^3.18.11",
+        "@data-driven-forms/react-form-renderer": "^3.18.11",
+        "@patternfly/patternfly": "4.132.2",
+        "@patternfly/quickstarts": "^2.3.1",
+        "@patternfly/react-charts": "^6.92.0",
+        "@patternfly/react-core": "4.175.4",
+        "@patternfly/react-icons": "^4.90.0",
+        "@patternfly/react-styles": "^4.89.0",
+        "@patternfly/react-table": "4.29.58",
+        "@patternfly/react-tokens": "^4.91.0",
+        "@redhat-cloud-services/frontend-components": "3.4.1",
+        "@redhat-cloud-services/frontend-components-inventory-general-info": "^3.4.0",
+        "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
+        "@redhat-cloud-services/frontend-components-utilities": "3.2.3",
+        "@redhat-cloud-services/host-inventory-client": "^1.0.111",
+        "@unleash/proxy-client-react": "^1.0.4",
+        "babel-plugin-transform-imports": "^2.0.0",
+        "chai-sorted": "^0.2.0",
+        "classnames": "2.3.1",
+        "lodash": "^4.17.21",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "react-redux": "7.2.5",
+        "react-router-dom": "5.3.0",
+        "redux": "4.1.1",
+        "redux-logger": "3.0.6",
+        "redux-promise-middleware": "6.1.2",
+        "sass-loader": "^12.6.0"
+    },
+    "devDependencies": {
+        "@babel/core": "7.15.5",
+        "@babel/plugin-proposal-object-rest-spread": "7.15.6",
+        "@babel/plugin-syntax-dynamic-import": "7.8.3",
+        "@babel/plugin-transform-runtime": "7.15.0",
+        "@babel/preset-env": "7.15.6",
+        "@babel/preset-flow": "7.14.5",
+        "@babel/preset-react": "7.14.5",
+        "@cypress/code-coverage": "^3.10.0",
+        "@redhat-cloud-services/eslint-config-redhat-cloud-services": "1.2.1",
+        "@redhat-cloud-services/frontend-components-config": "4.6.18",
+        "@testing-library/react": "^12.1.5",
+        "@webpack-cli/serve": "^1.6.1",
+        "babel-core": "7.0.0-bridge.0",
+        "babel-eslint": "10.1.0",
+        "babel-jest": "27.2.0",
+        "babel-plugin-dual-import": "1.2.1",
+        "babel-plugin-lodash": "3.3.4",
+        "cross-fetch": "^3.1.5",
+        "css-loader": "6.2.0",
+        "cypress": "^10.9.0",
+        "eslint": "7.32.0",
+        "eslint-config-prettier": "8.3.0",
+        "eslint-loader": "4.0.2",
+        "eslint-plugin-react": "7.25.1",
+        "eslint-plugin-react-hooks": "4.2.0",
+        "husky": "^7.0.0",
+        "identity-obj-proxy": "3.0.0",
+        "jest": "^27.5.1",
+        "jest-fetch-mock": "^3.0.3",
+        "node-sass": "7.0.1",
+        "npm-run-all": "4.1.5",
+        "postcss": "8.3.6",
+        "prop-types": "15.7.2",
+        "redux-mock-store": "^1.5.4",
+        "sass": "^1.55.0",
+        "stylelint": "13.13.1",
+        "stylelint-config-recommended-scss": "4.3.0",
+        "stylelint-scss": "3.21.0",
+        "webpack": "5.57.1",
+        "webpack-bundle-analyzer": "^4.6.1",
+        "webpack-cli": "4.9.1",
+        "webpack-dev-server": "^4.6.0"
+    },
+    "engines": {
+        "node": ">=16.13.0 <= 16.13.1",
+        "npm": ">=7.0.0"
+    },
+    "insights": {
+        "appname": "edge"
+    }
 }

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="edge"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/edge-frontend"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+#16 is the default Node version. Change this to override it.
+export NODE_BUILD_VERSION=16
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+
+IQE_PLUGINS="edge"
+IQE_MARKER_EXPRESSION="smoke"
+IQE_FILTER_EXPRESSION=""
+    
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# Stubbed out for now
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS


### PR DESCRIPTION
This patch adds the files required for the frontend containerization migration effort in https://issues.redhat.com/browse/RHCLOUD-21390

This patch includes:

- build and pr check scripts
- frontend resource yaml
- remove jest cache from test

This patch has no production impact - you'll keep doing everything you're doing today; this new config just gets us ready for the new pipeline.