### PR TITLE
DO NOT MERGE-THEEDGE2665

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,7 +3,6 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import React, { Suspense } from 'react';
 import { routes as paths } from './constants/routeMapper';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { useFeatureFlags } from './utils';
 // const Groups = React.lazy(() =>
 //   import(/* webpackChunkName: "GroupsPage" */ './Routes/Groups/Groups')
 // );
@@ -88,9 +87,8 @@ export const Routes = () => {
         <Route path={paths['manage-images-detail']} component={ImageDetail} />
         <Route path={paths['manage-images']} component={Images} />
 
-        {useFeatureFlags('fleet-management.custom-repos') && (
-          <Route exact path={paths['repositories']} component={Repositories} />
-        )}
+        <Route path={paths['respositories']} component={Repositories} />
+
         <Route
           exact
           path={paths['learning-resources']}


### PR DESCRIPTION
THEEDGE2665 was a bug that when refreshing the page on the Custom Repos page would redirect to the Groups page. Taking out the FeatureFlag helped ensure that the browers was directed to the correct place. 

## Type of change

What is it?

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted