### PR TITLE
Use autoFocus for name field in CreateGroupModal schema

### DIFF
--- a/src/Routes/Groups/CreateGroupModal.js
+++ b/src/Routes/Groups/CreateGroupModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
@@ -31,6 +31,7 @@ const createGroupSchema = {
       helperText:
         'Can only contain letters, numbers, spaces, hyphens ( - ), and underscores( _ ).',
       isRequired: true,
+      autoFocus: true,
       validate: [
         { type: validatorTypes.REQUIRED },
 
@@ -49,18 +50,6 @@ const CreateGroupModal = ({
   reloadData,
 }) => {
   const dispatch = useDispatch();
-
-  useEffect(() => {
-    /*
-      temp focus solution, better approach to pass a ref input and set it
-      when form inputs are mounted
-    */
-
-    setTimeout(() => {
-      const input = document.querySelector('#name');
-      if (input) input.focus();
-    }, 50);
-  }, []);
 
   const handleCreateGroup = (values) => {
     const statusMessages = {


### PR DESCRIPTION
# Description

This PR uses the `autoFocus` schema property for the `name` field in `CreateGroupModal`, instead of manually setting the focus in a `useEffect` hook. The functionality remains the same, but the number of renders of the modal is reduced.

The `Group name` text field should still automatically get focus when you open this modal:
- On the Groups page, click "Create Group".
- On the Systems page, click one or more system checkboxes > click on the kebab in the table's toolbar > click "Add to group" > click "Create Group".

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted