### PR TITLE
Fix async name validation

### DIFF
--- a/src/Routes/Groups/CreateGroupModal.js
+++ b/src/Routes/Groups/CreateGroupModal.js
@@ -18,11 +18,8 @@ const asyncGroupNameValidation = async (value = '') => {
     return undefined;
   }
   const resp = await validateGroupName(value);
-  // isValid should be isNotValid
-  // who wrote that Go code :thinking_face:
-  // spoiler: it was me
   if (resp.data.isValid) {
-    // async validator has to throw and error not return it
+    // async validator has to throw error, not return it
     throw 'Group name already exists';
   }
 };
@@ -41,10 +38,9 @@ const createGroupSchema = {
         'Can only contain letters, numbers, spaces, hyphens ( - ), and underscores( _ ).',
       isRequired: true,
       validate: [
-        // async validator has to be firs in the validatio config
+        // async validator has to be first in the list
         { type: 'groupName' },
         { type: validatorTypes.REQUIRED },
-
         { type: validatorTypes.MAX_LENGTH, threshold: 50 },
         nameValidator,
       ],

--- a/src/Routes/Groups/CreateGroupModal.js
+++ b/src/Routes/Groups/CreateGroupModal.js
@@ -12,14 +12,23 @@ import { nameValidator } from '../../utils';
 import apiWithToast from '../../utils/apiWithToast';
 import { useDispatch } from 'react-redux';
 
-const asyncGroupNameValidation = async (value) => {
+const asyncGroupNameValidation = async (value = '') => {
+  // do not fire validation request for empty name
+  if (value.length === 0) {
+    return undefined;
+  }
   const resp = await validateGroupName(value);
   // isValid should be isNotValid
   // who wrote that Go code :thinking_face:
   // spoiler: it was me
   if (resp.data.isValid) {
-    return 'Group name already exists';
+    // async validator has to throw and error not return it
+    throw 'Group name already exists';
   }
+};
+
+const validatorMapper = {
+  groupName: () => asyncGroupNameValidation,
 };
 
 const createGroupSchema = {
@@ -32,11 +41,12 @@ const createGroupSchema = {
         'Can only contain letters, numbers, spaces, hyphens ( - ), and underscores( _ ).',
       isRequired: true,
       validate: [
+        // async validator has to be firs in the validatio config
+        { type: 'groupName' },
         { type: validatorTypes.REQUIRED },
 
         { type: validatorTypes.MAX_LENGTH, threshold: 50 },
         nameValidator,
-        asyncGroupNameValidation,
       ],
     },
   ],
@@ -100,6 +110,7 @@ const CreateGroupModal = ({
       schema={createGroupSchema}
       onSubmit={deviceIds ? handleAddDevicesToNewGroup : handleCreateGroup}
       reloadData={reloadData}
+      validatorMapper={validatorMapper}
     />
   );
 };

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -9,22 +9,26 @@ import { nameValidator } from '../../../utils';
 const helperText =
   'Can only contain letters, numbers, spaces, hyphens ( - ), and underscores( _ ).';
 
-const asyncImageNameValidation = (value) =>
-  checkImageName(value)
-    .then((result) => {
-      if (result.ImageExists) {
-        throw new Error('Name already exists');
-      }
-    })
-    .catch(({ message }) => {
-      throw message;
-    });
+const asyncImageNameValidation = async (value = '') => {
+  // do not fire validation request for empty name
+  if (value.length === 0) {
+    return undefined;
+  }
+  const resp = await checkImageName(value);
+  if (resp.ImageExists) {
+    // async validator has to throw error, not return it
+    throw 'Name already exists';
+  }
+};
 
 const CharacterCount = () => {
   const { getState } = useFormApi();
   const description = getState().values?.description;
   return <h1>{description?.length || 0}/250</h1>;
 };
+
+export const imageNameValidator = () => (value) =>
+  asyncImageNameValidation(value);
 
 export default {
   title: 'Details',
@@ -47,10 +51,10 @@ export default {
       placeholder: 'Image name',
       helperText: helperText,
       validate: [
-        asyncImageNameValidation,
+        { type: 'imageNameValidator' },
         { type: validatorTypes.REQUIRED },
-        nameValidator,
         { type: validatorTypes.MAX_LENGTH, threshold: 50 },
+        nameValidator,
       ],
       isRequired: true,
     },

--- a/src/Routes/Repositories/modals/AddModal.js
+++ b/src/Routes/Repositories/modals/AddModal.js
@@ -10,11 +10,20 @@ import { nameValidator } from '../../../utils';
 import apiWithToast from '../../../utils/apiWithToast';
 import { useDispatch } from 'react-redux';
 
-const asyncRepoNameValidation = async (value) => {
+const asyncRepoNameValidation = async (value = '') => {
+  // do not fire validation request for empty name
+  if (value.length === 0) {
+    return undefined;
+  }
   const resp = await validateRepoName(value);
   if (resp.data.isValid) {
-    return 'Repository name already exists';
+    // async validator has to throw error, not return it
+    throw 'Repository name already exists';
   }
+};
+
+const validatorMapper = {
+  repoName: () => asyncRepoNameValidation,
 };
 
 const AddModal = ({ isOpen, closeModal, reloadData }) => {
@@ -52,9 +61,10 @@ const AddModal = ({ isOpen, closeModal, reloadData }) => {
           'Can only contain letters, numbers, spaces, hyphens ( - ), and underscores( _ ).',
         isRequired: true,
         validate: [
+          // async validator has to be first in the list
+          { type: 'repoName' },
           { type: validatorTypes.REQUIRED },
           nameValidator,
-          asyncRepoNameValidation,
         ],
       },
       {
@@ -81,6 +91,7 @@ const AddModal = ({ isOpen, closeModal, reloadData }) => {
       schema={addSchema}
       onSubmit={handleAddRepository}
       reloadData={reloadData}
+      validatorMapper={validatorMapper}
     />
   );
 };

--- a/src/components/ImageCreator.js
+++ b/src/components/ImageCreator.js
@@ -14,6 +14,7 @@ import SSHInputField from './form/SSHInputField';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { registrationCredsValidator } from './form/RegistrationCreds';
 import { reservedUsernameValidator } from './form/validators';
+import { imageNameValidator } from '../Routes/ImageManager/steps/imageSetDetails.js';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import CustomPackageTextArea from './form/CustomPackageTextArea';
 
@@ -89,6 +90,7 @@ const CreateImageWizard = ({
         ...validatorTypes,
         registrationCredsValidator,
         reservedUsernameValidator,
+        imageNameValidator,
       }}
       onCancel={onClose}
     />

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -18,6 +18,7 @@ const RepoModal = ({
   size,
   onSubmit,
   additionalMappers,
+  validatorMapper,
 }) => {
   return (
     <Modal
@@ -29,6 +30,7 @@ const RepoModal = ({
     >
       <FormRenderer
         schema={schema}
+        validatorMapper={validatorMapper}
         FormTemplate={(props) => (
           <FormTemplate
             {...props}
@@ -69,6 +71,7 @@ RepoModal.propTypes = {
   size: PropTypes.string,
   additionalMappers: PropTypes.object,
   titleIconVariant: PropTypes.any,
+  validatorMapper: PropTypes.object,
 };
 
 export default RepoModal;


### PR DESCRIPTION
# Description

This PR fixes an issue with the async name validators for:
- new group name in the Create Group modal
- new image set name in Create Image wizard
- new custom repo name in Create Repo modal

When a group, image set, or custom repo is created in the UI, the data-driven-forms library caches the results of the name validators. If the user then tries to create it again with the same name, the original cached validator response from the first attempt is re-used, and the name is allowed once more.

This PR fixes the issue by refactoring the validators to come from the `FormRenderer`'s `validatorMapper`.

Fixes # (THEEDGE-2481)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted