### PR TITLE
Change node version in frontend scripts to 14 to match this project.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -11,7 +11,7 @@ export IMAGE="quay.io/cloudservices/edge-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 #16 is the default Node version. Change this to override it.
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=14
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 set -exv

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -10,7 +10,7 @@ export IMAGE="quay.io/cloudservices/edge-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 #16 is the default Node version. Change this to override it.
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=14
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
This patch switches the node version in the `build_deploy.sh` and `pr_check.sh` to 14 in order to match your project (it was 16 by default.) I'm making this change because builds are failing in our new test environment. 

Note that none of this affects your production pipelines today, this is all for the container stuff.