### PR TITLE
Fix typo in custom repo route path

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -87,7 +87,7 @@ export const Routes = () => {
         <Route path={paths['manage-images-detail']} component={ImageDetail} />
         <Route path={paths['manage-images']} component={Images} />
 
-        <Route exact path={paths['respositories']} component={Repositories} />
+        <Route exact path={paths['repositories']} component={Repositories} />
 
         <Route
           exact


### PR DESCRIPTION
# Description

https://github.com/RedHatInsights/edge-frontend/pull/573 introduced a typo in the route for custom repositories. This resulted in /beta/edge displaying the custom repositories page instead of redirecting to the groups page at /beta/edge/fleet-management.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted