### PR TITLE
Fix async name validation and step navigation in image wizard

### DIFF
--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -6,7 +6,7 @@ import {
   review,
   packages,
   repositories,
-  imageSetDetails,
+  getImageSetDetailsSchema,
   imageOutput,
   customPackages,
 } from './steps';
@@ -31,6 +31,7 @@ const CreateImage = ({ navigateBack, reload }) => {
     navigateBack();
     reload && reload();
   };
+
   useEffect(() => {
     (async () => {
       insights?.chrome?.auth
@@ -38,6 +39,10 @@ const CreateImage = ({ navigateBack, reload }) => {
         .then((result) => setUser(result != undefined ? result : {}));
     })();
   }, []);
+
+  // Re-initialize imageSetDetails schema each render, to avoid cache
+  // of async validator results across multiple instances of the form.
+  const imageSetDetails = getImageSetDetailsSchema();
 
   return user ? (
     <ImageCreator
@@ -119,13 +124,10 @@ const CreateImage = ({ navigateBack, reload }) => {
             showTitles: true,
             title: 'Create image',
             crossroads: [
-              'target-environment',
               'release',
               'imageType',
               'third-party-repositories',
               'imageOutput',
-              'imageSetDetails',
-              'includesCustomRepos',
             ],
             // order in this array does not reflect order in wizard nav, this order is managed inside
             // of each step by `nextStep` property!

--- a/src/Routes/ImageManager/steps/imageSetDetails.js
+++ b/src/Routes/ImageManager/steps/imageSetDetails.js
@@ -9,25 +9,13 @@ import { nameValidator } from '../../../utils';
 const helperText =
   'Can only contain letters, numbers, spaces, hyphens ( - ), and underscores( _ ).';
 
-const asyncImageNameValidation = async (value = '') => {
-  // do not fire validation request for empty name
-  if (value.length === 0) {
-    return undefined;
-  }
-  const resp = await checkImageName(value);
-  if (resp.ImageExists) {
-    // async validator has to throw error, not return it
-    throw 'Name already exists';
-  }
-};
-
 const CharacterCount = () => {
   const { getState } = useFormApi();
   const description = getState().values?.description;
   return <h1>{description?.length || 0}/250</h1>;
 };
 
-export default {
+const getImageSetDetailsSchema = () => ({
   title: 'Details',
   name: 'imageSetDetails',
   nextStep: 'imageOutput',
@@ -48,7 +36,18 @@ export default {
       placeholder: 'Image name',
       helperText: helperText,
       validate: [
-        asyncImageNameValidation,
+        // Define async validator inline here, so that results are not cached
+        async (value = '') => {
+          // Do not fire validation request for empty name
+          if (value.length === 0) {
+            return undefined;
+          }
+          const resp = await checkImageName(value);
+          if (resp.ImageExists) {
+            // Async validator has to throw error, not return it
+            throw 'Name already exists';
+          }
+        },
         { type: validatorTypes.REQUIRED },
         { type: validatorTypes.MAX_LENGTH, threshold: 50 },
         nameValidator,
@@ -73,9 +72,10 @@ export default {
         </Flex>
       ),
       placeholder: 'Add description',
-
       resizeOrientation: 'vertical',
       validate: [{ type: validatorTypes.MAX_LENGTH, threshold: 250 }],
     },
   ],
-};
+});
+
+export default getImageSetDetailsSchema;

--- a/src/Routes/ImageManager/steps/index.js
+++ b/src/Routes/ImageManager/steps/index.js
@@ -1,7 +1,7 @@
 export { default as review } from './review';
 export { default as packages } from './packages';
 export { default as imageOutput } from './imageOutput';
-export { default as imageSetDetails } from './imageSetDetails';
+export { default as getImageSetDetailsSchema } from './imageSetDetails';
 export { default as updateDetails } from './updateDetails';
 export { default as registration } from './registration';
 export { default as repositories } from './repositories';


### PR DESCRIPTION
# Description

This PR fixes a few issues with the create image wizard:
- When creating two images in a row, the second image wizard doesn't prevent you from using the same name, because the async name validator was caching return values across multiple instances of the wizard.
- An attempted fix was made in https://github.com/RedHatInsights/edge-frontend/pull/576, but then reverted in https://github.com/RedHatInsights/edge-frontend/pull/579 because it introduced or uncovered more issues with step navigation in the wizard. (Some of these issues also appeared even without the async name validatory fix, however.)
     - Enter a unique name in `Image name` and verify that `Next` becomes enabled. Click `Next`. See that `Next` is disabled on the `Options` step, even though the initial values are all valid. (Unchecking and rechecking the `RHEL for Edge installer (.iso)` option enables the `Next` button.)
   - From the `Options` step, click `Back` to return to the `Details` step. Sometimes (you may need to go back and forth a couple times) the `Next` button is disabled on the `Details` step until you click on or modify `Image name` or `Description`.

With this PR, the schema and validator for the `Details` step are re-initialized each time the component is rendered, so that any cached values from previous form instances are cleared.

- When creating two images in a row, the second image wizard instance should disable the `Next` button on the `Details` step if re-using the first image's name.
- `Next` and `Back` should be enabled or disabled as expected, depending on whether all required fields are present and valid on each step.

Fixes # (THEEDGE-2814)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted