### PR TITLE
Add cypress tests for large HTTP headers

### DIFF
--- a/cypress/e2e/groups/Groups.cy.js
+++ b/cypress/e2e/groups/Groups.cy.js
@@ -1,22 +1,26 @@
 describe('Groups', () => {
   before(() => {
-    cy.beforeTest('/fleet-management')
+    cy.beforeTest('/fleet-management');
   });
 
   it('groups happy path', () => {
-    cy.get('.pf-c-title', { timeout: 30000 }).should('include.text', 'Groups')
-    cy.get('.pf-c-search-input__text-input').type('cy-group')
-    cy.wait(500)
-    cy.get('tbody [data-label="Name"] > a').should('include.text', 'cy-group')
-    cy.wait(500).clickButton('Clear filters')
-    cy.wait(500)
+    cy.get('.pf-c-title', { timeout: 30000 }).should('include.text', 'Groups');
+    cy.get('.pf-c-search-input__text-input').type('cy-group');
+    cy.wait(500);
+    cy.get('tbody [data-label="Name"] > a').should('include.text', 'cy-group');
+    cy.wait(500).clickButton('Clear filters');
+    cy.wait(500);
     
-    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible')
-    cy.sorting('tbody [data-label="Name"]', 'asc')
-    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible').click()
-    cy.wait(1000)
-    cy.sorting('tbody [data-label="Name"]', 'des')
-    cy.wait(500).testPagination('', 'perPage')
+    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible');
+    cy.sorting('tbody [data-label="Name"]', 'asc');
+    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible').click();
+    cy.wait(1000);
+    cy.sorting('tbody [data-label="Name"]', 'des');
+    cy.wait(500).testPagination('', 'perPage');
+  });
 
-  }) 
-})
+  it('groups max header test', () => {
+    cy.largeHeaderRequest('/fleet-management');
+  });
+
+});

--- a/cypress/e2e/images/Images.cy.js
+++ b/cypress/e2e/images/Images.cy.js
@@ -1,43 +1,46 @@
 describe('Images', () => {
   before(() => {
-    cy.beforeTest('/manage-images')    
+    cy.beforeTest('/manage-images');
   });
 
-  it('happy path', function () {  
-    cy.get('.pf-c-title', { timeout: 30000 }).should('include.text', 'Images')
+  it('manage images happy path', () => {
+    cy.get('.pf-c-title', { timeout: 30000 }).should('include.text', 'Images');
 
-    //Filter by Name
-    cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').click()
-    cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').contains('Name').click()
-    cy.get('.pf-c-search-input__text-input').type('cy-test')
-    cy.get('.pf-m-width-35 > a').should('include.text', 'cy-test')
-    cy.wait(500)
-    cy.iterateRows('a', 'cy-test')
-    cy.clickButton('Clear filters')
+    // Filter by Name
+    cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').click();
+    cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').contains('Name').click();
+    cy.get('.pf-c-search-input__text-input').type('cy-test');
+    cy.get('.pf-m-width-35 > a').should('include.text', 'cy-test');
+    cy.wait(500);
+    cy.iterateRows('a', 'cy-test');
+    cy.clickButton('Clear filters');
 
-    //Filter by Status - Ready
-    cy.selectInDropdownMenu('Status', 'Ready')
-    cy.iterateRows('p', 'Ready')
-    cy.clickButton('Clear filters')
+    // Filter by Status - Ready
+    cy.selectInDropdownMenu('Status', 'Ready');
+    cy.iterateRows('p', 'Ready');
+    cy.clickButton('Clear filters');
 
-    //Sort by Status - Error
-    cy.selectInDropdownMenu('Status', 'Error')
-    cy.iterateRows('p', 'Error')
-    cy.clickButton('Clear filters')
+    // Sort by Status - Error
+    cy.selectInDropdownMenu('Status', 'Error');
+    cy.iterateRows('p', 'Error');
+    cy.clickButton('Clear filters');
   
-    cy.wait(2000)
+    cy.wait(2000);
     cy.get('.pf-m-width-35 > .pf-c-table__button', { timeout: 30000 })
-      .should('be.visible').click()
-    cy.wait(2000)
-    cy.sorting('tbody [data-label="Name"]', 'asc')
-
+      .should('be.visible').click();
+    cy.wait(2000);
+    cy.sorting('tbody [data-label="Name"]', 'asc');
 
     cy.get('.pf-m-width-35 > .pf-c-table__button', { timeout: 30000 })
-      .should('be.visible').click()
-    cy.wait(2000)
-    cy.sorting('tbody [data-label="Name"]', 'des')
+      .should('be.visible').click();
+    cy.wait(2000);
+    cy.sorting('tbody [data-label="Name"]', 'des');
 
-    cy.testPagination('', 'perPage')
+    cy.testPagination('', 'perPage');
+  });
 
-  }) 
-})
+  it('manage images max header test', () => {
+    cy.largeHeaderRequest('/manage-images');
+  });
+
+});

--- a/cypress/e2e/repositories/CustomRepositories.cy.js
+++ b/cypress/e2e/repositories/CustomRepositories.cy.js
@@ -1,28 +1,31 @@
 describe('Custom repositories', () => {
   before(() => {
-    cy.beforeTest('/repositories')    
+    cy.beforeTest('/repositories');
   });
 
-  it('custom repositories happy path', function () {  
-    cy.get('.pf-c-title', { timeout: 30000 }).should('include.text', 'Custom repositories')
-    cy.get('p').first().should('include.text', this.contents.customRepositories)
-    cy.get('.pf-c-search-input__text-input').type('cy-repo')
+  // Use function instead of arrow function so that fixture data in 'this' is scoped correctly.
+  it('custom repositories happy path', function () {
+    cy.get('.pf-c-title', { timeout: 30000 }).should('include.text', 'Custom repositories');
+    cy.get('p').first().should('include.text', this.contents.customRepositories);
+    cy.get('.pf-c-search-input__text-input').type('cy-repo');
 
-    cy.wait(500)
+    cy.wait(500);
 
-    cy.get('[data-label="Name"] > p').should('include.text', 'cy-repo')
-    cy.wait(500).clickButton('Clear filters')
+    cy.get('[data-label="Name"] > p').should('include.text', 'cy-repo');
+    cy.wait(500).clickButton('Clear filters');
 
-    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible')
-    cy.sorting('tbody [data-label="Name"] > p', 'asc')
+    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible');
+    cy.sorting('tbody [data-label="Name"] > p', 'asc');
 
-    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible').click()
-    cy.wait(1000)
-    cy.sorting('tbody [data-label="Name"] > p', 'des')
+    cy.get('.pf-c-table__button', { timeout: 30000 }).should('be.visible').click();
+    cy.wait(1000);
+    cy.sorting('tbody [data-label="Name"] > p', 'des');
 
+    cy.wait(500).testPagination('', 'perPage');
+  });
 
-    cy.wait(500).testPagination('', 'perPage')
+  it('custom repositories max header test', () => {
+    cy.largeHeaderRequest('/repositories');
+  });
 
-
-  }) 
-})
+});

--- a/cypress/e2e/systems/Systems.cy.js
+++ b/cypress/e2e/systems/Systems.cy.js
@@ -1,0 +1,7 @@
+describe('Systems', () => {
+
+  it('systems max header test', () => {
+    cy.largeHeaderRequest('/inventory');
+  });
+
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,87 +24,90 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-//import { recurse } from 'cypress-recurse'
 Cypress.Commands.add('login', () => {
-  cy.visit(Cypress.config().baseUrl)
-  cy.get('#username-verification', { timeout: 30000 }).should('be.visible').type(Cypress.env('username'))
-  cy.get('#login-show-step2', { timeout: 30000 }).should('be.visible').click()
-  cy.get('#password', { timeout: 30000 }).should('be.visible').type(Cypress.env('password'))
-  cy.get('#rh-password-verification-submit-button').click()
-})
+  cy.visit(Cypress.config().baseUrl);
+  cy.get('#username-verification', { timeout: 30000 }).should('be.visible').type(Cypress.env('username'));
+  cy.get('#login-show-step2', { timeout: 30000 }).should('be.visible').click();
+  cy.get('#password', { timeout: 30000 }).should('be.visible').type(Cypress.env('password'));
+  cy.get('#rh-password-verification-submit-button').click();
+});
 
 Cypress.Commands.add('clearCookieConsentModal', () => {
-  const consentModal = Cypress.$('.truste_overlay')
+  const consentModal = Cypress.$('.truste_overlay');
   if (consentModal.length > 0) {
     cy.get('.truste_popframe').then((iframe) => {
       const body = iframe.contents().find('body');
-      cy.wrap(body).find('a.call').click()
-    })
+      cy.wrap(body).find('a.call').click();
+    });
   }
-})
+});
 
 Cypress.Commands.add('beforeTest', (url) => {
   cy.fixture("imageData").then(function (data) {
-    this.data = data
-    })
+    this.data = data;
+    });
   cy.fixture("contents").then(function (contents) {
-    this.contents = contents
-   })
-  cy.viewport(1600, 1000)
-  cy.login()
-  cy.clearCookieConsentModal()
-  cy.visit(url)
-
-})
+    this.contents = contents;
+   });
+  cy.viewport(1600, 1000);
+  cy.login();
+  cy.clearCookieConsentModal();
+  cy.visit(url);
+});
 
 Cypress.Commands.add('iterateRows', (element, value) => {
   cy.get(`tbody ${element}`).each(($element) => {
     cy.wrap($element)
-      .contains(value)
-  })
-
-})
+      .contains(value);
+  });
+});
 
 Cypress.Commands.add('selectInDropdownMenu', (label, status) => {
-  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').click()
-  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').contains(label).click()
-  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-input-testid"]').click()
-  cy.get('label').contains(status).click()
-  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-input-testid"]').click()
-
-})
+  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').click();
+  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-dropdown-testid"]').contains(label).click();
+  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-input-testid"]').click();
+  cy.get('label').contains(status).click();
+  cy.get('[data-testid="toolbar-header-testid"]').find('[data-testid="filter-input-testid"]').click();
+});
 
 Cypress.Commands.add('clickButton', (value) => {
-  cy.get('button').contains(value).click()
-})
+  cy.get('button').contains(value).click();
+});
 
 Cypress.Commands.add('testPagination', (selector, test) => {
-  if(test == "perPage"){    
+  if (test == "perPage") {    
     cy.wrap([10, 20, 50, 100]).each((num, i, array) => {
-      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('[data-testid="pagination-header-test-id"]').click()
-      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find(`[data-action="per-page-${num}"]`).click()
-      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('b').should('include.text', `1 - ${num}`)
-
-      })
-      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('[data-action="previous"]').should('to.be.disabled')
-      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('[data-action="next"]').should('to.not.be.disabled')    
-
-  }else{    
-
+      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('[data-testid="pagination-header-test-id"]').click();
+      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find(`[data-action="per-page-${num}"]`).click();
+      cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('b').should('include.text', `1 - ${num}`);
+      });
+    cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('[data-action="previous"]').should('to.be.disabled');
+    cy.get(`${selector} [data-testid="toolbar-header-testid"]`).find('[data-action="next"]').should('to.not.be.disabled');
   }
-})
+});
 
 Cypress.Commands.add('sorting', (selector, order) => {
-  const collator = new Intl.Collator('en-US', {ignorePunctuation: true})
+  const collator = new Intl.Collator('en-US', {ignorePunctuation: true});
   
   cy.get(selector)
   .then(($cell) => Cypress._.map($cell, (el) => el.innerText))
-  .then((list)=>{
+  .then((list) => {
     const sortedList = [...list].sort((a, b) => order === "asc" ? collator.compare(a, b) : collator.compare(b, a));
-    expect(list).to.deep.equal(sortedList)
+    expect(list).to.deep.equal(sortedList);
+  });
+});
 
+Cypress.Commands.add('largeHeaderRequest', (url) => {
+  // Verify 32 kiB header returns HTTP 431
+  const headerSize = 32*1024;
+  cy.request({
+    method: 'GET',
+    url,
+    headers: { 'X-test-long-header': 'x'.repeat(headerSize) },
+    failOnStatusCode: false,
   })
-  
-})
-
+  .then(response => {
+    expect(response.status).to.eq(431);
+  });
+});
 


### PR DESCRIPTION
# Description

This PR adds tests of maximum HTTP request header size, as well as restores the use of semicolons in the affected js files.

Fixes # (THEEDGE-2764)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted