### PR TITLE
Clean up custom repo and custom package steps in image wizard

### DIFF
--- a/src/Routes/ImageManager/steps/customPackage.js
+++ b/src/Routes/ImageManager/steps/customPackage.js
@@ -9,24 +9,24 @@ import {
   Text,
   TextContent,
 } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import { releaseMapper } from '../../../constants';
 
-const showAlert = (type) => {
-  return (
-    <Alert
-      className="pf-u-mt-lg"
-      variant={type}
-      isInline
-      title={
-        type === 'danger'
-          ? 'No custom repositories linked. Clear custom packages or link a repository.'
-          : 'Linked custom repositories were removed when these packages were added. Ensure the package list is still correct.'
-      }
-      style={{ '--pf-c-content--h4--MarginTop': 0 }}
-    />
-  );
+const CustomRepoAlert = ({ variant, title }) => (
+  <Alert
+    className="pf-u-mt-lg"
+    variant={variant}
+    isInline
+    title={title}
+    style={{ '--pf-c-content--h4--MarginTop': 0 }}
+  />
+);
+
+CustomRepoAlert.propTypes = {
+  variant: PropTypes.string,
+  title: PropTypes.string,
 };
 
 const checkRepoNameMismatch = (
@@ -40,11 +40,10 @@ const checkRepoNameMismatch = (
   if (currentRepos.length < initRepos.length) {
     return true;
   }
-
-  const isMismatch = !initRepos.every((iRepo) =>
+  // Mismatch if any initial repo is no longer selected
+  return !initRepos.every((iRepo) =>
     currentRepos.find((cRepo) => cRepo.name === iRepo.name)
   );
-  return isMismatch;
 };
 
 const CustomPackageLabel = () => {
@@ -88,11 +87,17 @@ const CustomPackageLabel = () => {
           <b> {releaseName}</b> image.
         </Text>
       </TextContent>
-      {addedRepos.length === 0 && customPackages.length > 0
-        ? showAlert('danger')
-        : checkRepoNameMismatch(initialRepos, addedRepos, customPackages)
-        ? showAlert('warning')
-        : null}
+      {addedRepos.length === 0 && customPackages.length > 0 ? (
+        <CustomRepoAlert
+          variant="danger"
+          title="No custom repositories linked. Clear custom packages or link a repository."
+        />
+      ) : checkRepoNameMismatch(initialRepos, addedRepos, customPackages) ? (
+        <CustomRepoAlert
+          variant="warning"
+          title="Linked custom repositories were removed when these packages were added. Ensure the package list is still correct."
+        />
+      ) : null}
     </>
   );
 };
@@ -106,7 +111,6 @@ export default {
     {
       component: componentTypes.PLAIN_TEXT,
       name: 'description',
-
       label: <CustomPackageLabel />,
     },
     {

--- a/src/components/form/CustomPackageTextArea.js
+++ b/src/components/form/CustomPackageTextArea.js
@@ -1,40 +1,25 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { FormGroup, TextArea } from '@patternfly/react-core';
-import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 
-const CustomPackageTextArea = ({ ...props }) => {
-  const { change, getState } = useFormApi();
+const CustomPackageTextArea = (props) => {
   const { input } = useFieldApi(props);
-  const wizardState = getState()?.values?.[input.name];
   const [value, setValue] = useState(
-    wizardState?.map((repo) => repo.name).join('\n')
+    input.value.map((pkg) => pkg.name).join('\n')
   );
 
-  useEffect(() => {
-    const customRepoArray = value
-      .split(/[/,/\n\r\s\t]+/g)
-      .reduce((acc, repo) => {
-        const onlyText = repo.replace(/[/ /\n\r\s\t]+/g, '');
-        if (onlyText !== '' && onlyText !== '\n') {
-          return (acc = [...acc, { name: `${onlyText}` }]);
-        }
-        return acc;
-      }, []);
-    change(input.name, customRepoArray);
-  }, [value]);
-
-  useEffect(() => {
-    const availableSearchInput = document.querySelector(
-      '[aria-label="custom-package-wizard-step"]'
-    );
-
-    availableSearchInput?.addEventListener('keydown', handleSearchOnEnter);
-    return () =>
-      availableSearchInput.removeEventListener('keydown', handleSearchOnEnter);
-  }, []);
+  const onChange = (newValue) => {
+    // Split text area value on whitespace or commas to get package names
+    const packageNames = newValue.split(/[,\s]+/g).reduce((acc, name) => {
+      return name !== '' ? [...acc, { name }] : acc;
+    }, []);
+    // Store both the formatted array and the original text
+    input.onChange(packageNames);
+    setValue(newValue);
+  };
 
   const handleSearchOnEnter = (e) => {
+    // Allow newlines in text area component
     if (e.key === 'Enter') {
       e.stopPropagation();
     }
@@ -44,14 +29,15 @@ const CustomPackageTextArea = ({ ...props }) => {
     <FormGroup label="Packages" type="string">
       <TextArea
         aria-label="custom-package-wizard-step"
-        placeholder="Enter or paste packages from linked repositories, one entry per line.&#13;ExamplePackage&#13;example-package&#13;examplapackage"
+        placeholder="Enter or paste packages from linked repositories, one entry per line.&#13;ExamplePackage&#13;example-package&#13;examplepackage"
         value={value}
-        onChange={(newValue) => setValue(newValue)}
+        onChange={onChange}
+        onKeyDown={handleSearchOnEnter}
         style={{
           paddingRight: '32px',
           height: '25vh',
         }}
-      ></TextArea>
+      />
     </FormGroup>
   );
 };

--- a/src/components/form/WizardRepositoryTable.js
+++ b/src/components/form/WizardRepositoryTable.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import GeneralTable from '../general-table/GeneralTable';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Text, TextVariants } from '@patternfly/react-core';
@@ -12,14 +12,12 @@ import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import { truncateString } from '../../utils';
 const filters = [{ label: 'Name', type: 'text' }];
 
-const WizardRepositoryTable = ({ ...props }) => {
+const WizardRepositoryTable = (props) => {
   const { change, getState } = useFormApi();
   const { input } = useFieldApi(props);
-  const wizardState = getState()?.values?.[input.name];
   const isUpdateWizard = getState()?.values?.isUpdate;
   const imageID = getState()?.values?.imageID;
 
-  const [selectedRepos, setSelectedRepos] = useState([]);
   const [response, fetchRepos] = useApi({
     api: ({ query }) =>
       getCustomRepositories({
@@ -30,17 +28,13 @@ const WizardRepositoryTable = ({ ...props }) => {
   });
   const { data, isLoading, hasError } = response;
 
-  useEffect(() => {
-    change(input.name, selectedRepos);
-  }, [selectedRepos]);
-
   const getRepoIds = (checked) => {
     const checkedRepos = checked?.map((repo) => ({
       id: repo?.id,
       name: repo?.name,
       URL: repo?.URL,
     }));
-    setSelectedRepos(checkedRepos);
+    input.onChange(checkedRepos);
   };
 
   useEffect(() => {
@@ -74,7 +68,7 @@ const WizardRepositoryTable = ({ ...props }) => {
 
   return (
     <>
-      {isLoading !== true && !data?.count > 0 ? (
+      {!isLoading && !data?.count > 0 ? (
         <EmptyState
           icon="repository"
           title="No custom repositories available"
@@ -101,7 +95,7 @@ const WizardRepositoryTable = ({ ...props }) => {
           defaultSort={{ index: 0, direction: 'desc' }}
           hasCheckbox={true}
           selectedItems={getRepoIds}
-          initSelectedItems={wizardState}
+          initSelectedItems={input.value}
         />
       )}
     </>


### PR DESCRIPTION
# Description

There are occasional issues in the image wizard in test automation, where the `Next` button remains disabled on the `Custom packages` step, even though no custom repos are selected and the custom packages text area is empty. This PR attempts to fix the issue by cleaning up the field state management in some of the relevant components. The main changes are:

`CustomPackageTextArea`:
- Removed unnecessary imports from `useFormApi`.
- Simplified code that parses the user's text input into an array of packages, and fixed misleading variable naming ("packages" were referred to as "repos").
- Removed the first `useEffect` hook, and moved the field value update into the `onChange` handler.
- Remove the second `useEffect` hook, and passed the `handleSearchOnEnter` event handler directly to `TextArea`'s `onKeyDown` prop.

`WizardRepositoryTable`:
- Removed the `useEffect` hook, and moved the field value update into the `getRepoIds` handler.

These changes will cut down on the number of component re-renders and simplify the field state management, and hopefully resolve form validation issues like the one mentioned above.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted