### PR TITLE
Move jest test script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
         "start:proxy": "PROXY=true NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
         "start:federated": "BETA=true fec static --config config/dev.webpack.config.js",
-        "test": "jest --verbose",
+        "test": "TZ=UTC jest --verbose --no-cache",
         "verify": "npm-run-all build lint test",
         "prepare": "husky install"
     },
@@ -38,8 +38,7 @@
         "setupFiles": [
             "<rootDir>/config/setupTests.js"
         ],
-        "testEnvironment": "jsdom",
-        "test": "TZ=UTC jest --verbose --no-cache"
+        "testEnvironment": "jsdom"
     },
     "transformIgnorePatterns": [
         "/node_modules/(?!@redhat-cloud-services)"


### PR DESCRIPTION
This PR moves jest.test to scripts.test - I mistakenly put it in the wrong place.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted