### PR TITLE
Fix broken system detail page

### DIFF
--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -141,6 +141,7 @@ const DeviceDetail = () => {
             ]}
             hideBack
             hideInvDrawer
+            inventoryId={deviceId}
           />
 
           {isDeviceStatusLoading ? (


### PR DESCRIPTION
# Description

The `InventoryDetailHead` component has recently been updated, breaking our system detail page. This PR updates `DeviceDetail` to pass the new `inventoryId` prop to `InventoryDetailHead`, so that it has the correct device id.

Fixes # (THEEDGE-2825)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted