### PR TITLE
Remove deprecated frontend-components-inventory-general-info package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "@patternfly/react-table": "^4.111.33",
                 "@patternfly/react-tokens": "^4.93.10",
                 "@redhat-cloud-services/frontend-components": "^3.9.20",
-                "@redhat-cloud-services/frontend-components-inventory-general-info": "^3.4.0",
                 "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
                 "@redhat-cloud-services/frontend-components-utilities": "^3.3.3",
                 "@redhat-cloud-services/host-inventory-client": "^1.0.111",
@@ -4344,83 +4343,6 @@
                 "decamelize": "^1.2.0"
             }
         },
-        "node_modules/@redhat-cloud-services/frontend-components-inventory": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory/-/frontend-components-inventory-3.4.0.tgz",
-            "integrity": "sha512-qfm2HcI8Y2xP1fRL/+yft5SJcraqjBAt62defBcf4tw+yz4Ah8enmGAoq6Or2xv6GlH9wfjO6cP5tCRzAyDcDQ==",
-            "dependencies": {
-                "@redhat-cloud-services/frontend-components": ">=3.0.0",
-                "@redhat-cloud-services/frontend-components-notifications": ">=3.0.0",
-                "@redhat-cloud-services/frontend-components-utilities": ">3.0.0",
-                "@redhat-cloud-services/host-inventory-client": "1.0.96",
-                "axios": "^0.21.4"
-            },
-            "peerDependencies": {
-                "@patternfly/react-core": ">=4.18.5",
-                "@patternfly/react-icons": ">=4.3.5",
-                "@patternfly/react-table": ">=4.5.7",
-                "prop-types": ">=15.6.2",
-                "react": ">=16.14.0 || >=17.0.0",
-                "react-content-loader": ">=3.4.1",
-                "react-dom": ">=16.14.0 || >=17.0.0",
-                "react-redux": ">=5.0.7",
-                "react-router-dom": ">=4.2.2"
-            }
-        },
-        "node_modules/@redhat-cloud-services/frontend-components-inventory-general-info": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-general-info/-/frontend-components-inventory-general-info-3.4.0.tgz",
-            "integrity": "sha512-AJAL5sfSDCRK29e1tO1EoQ94Q65Uh0/Wwd39S/JE8LrlkO6s+17hoz16a1PeOtBFppu7QROOA1hcMQqjBUlnLg==",
-            "dependencies": {
-                "@redhat-cloud-services/frontend-components": ">=3.0.0",
-                "@redhat-cloud-services/frontend-components-inventory": "*",
-                "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
-                "@redhat-cloud-services/host-inventory-client": "1.0.91",
-                "abortcontroller-polyfill": "^1.7.1",
-                "prop-types": "^15.7.2",
-                "react-redux": "^7.2.4",
-                "redux": "^4.1.0"
-            },
-            "peerDependencies": {
-                "@patternfly/react-core": "^4.115.2",
-                "@patternfly/react-icons": "^4.10.2",
-                "@patternfly/react-table": "^4.26.7",
-                "react": ">=16.14.0 || >=17.0.0",
-                "react-dom": ">=16.14.0 || >=17.0.0"
-            }
-        },
-        "node_modules/@redhat-cloud-services/frontend-components-inventory-general-info/node_modules/@redhat-cloud-services/host-inventory-client": {
-            "version": "1.0.91",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.91.tgz",
-            "integrity": "sha512-UeDEOrhxs8ztJh2qzw0isIDWN1AHxV7Aybnoe2l0T9fg1uiFP4B2wmuE2J5FUv1TCt3V2Op7cW+vqMA4VC/t0A==",
-            "dependencies": {
-                "axios": "^0.21.1"
-            }
-        },
-        "node_modules/@redhat-cloud-services/frontend-components-inventory-general-info/node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
-        "node_modules/@redhat-cloud-services/frontend-components-inventory/node_modules/@redhat-cloud-services/host-inventory-client": {
-            "version": "1.0.96",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.96.tgz",
-            "integrity": "sha512-OJxEGDesHXc7vKdb86SBZ5pNnaWDerNjE0hAiGktUvKXBqZY3Ag/k6IaYKZPE0TYMFRgjJPsyLTVBTpu1JQAow==",
-            "dependencies": {
-                "axios": "^0.21.1"
-            }
-        },
-        "node_modules/@redhat-cloud-services/frontend-components-inventory/node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
         "node_modules/@redhat-cloud-services/frontend-components-notifications": {
             "version": "3.2.12",
             "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.12.tgz",
@@ -5484,11 +5406,6 @@
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "devOptional": true
-        },
-        "node_modules/abortcontroller-polyfill": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
-            "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
         },
         "node_modules/accepts": {
             "version": "1.3.8",
@@ -25145,69 +25062,6 @@
                 "node-fetch": "2.6.7"
             }
         },
-        "@redhat-cloud-services/frontend-components-inventory": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory/-/frontend-components-inventory-3.4.0.tgz",
-            "integrity": "sha512-qfm2HcI8Y2xP1fRL/+yft5SJcraqjBAt62defBcf4tw+yz4Ah8enmGAoq6Or2xv6GlH9wfjO6cP5tCRzAyDcDQ==",
-            "requires": {
-                "@redhat-cloud-services/frontend-components": ">=3.0.0",
-                "@redhat-cloud-services/frontend-components-notifications": ">=3.0.0",
-                "@redhat-cloud-services/frontend-components-utilities": ">3.0.0",
-                "@redhat-cloud-services/host-inventory-client": "1.0.96",
-                "axios": "^0.21.4"
-            },
-            "dependencies": {
-                "@redhat-cloud-services/host-inventory-client": {
-                    "version": "1.0.96",
-                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.96.tgz",
-                    "integrity": "sha512-OJxEGDesHXc7vKdb86SBZ5pNnaWDerNjE0hAiGktUvKXBqZY3Ag/k6IaYKZPE0TYMFRgjJPsyLTVBTpu1JQAow==",
-                    "requires": {
-                        "axios": "^0.21.1"
-                    }
-                },
-                "axios": {
-                    "version": "0.21.4",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-                    "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-                    "requires": {
-                        "follow-redirects": "^1.14.0"
-                    }
-                }
-            }
-        },
-        "@redhat-cloud-services/frontend-components-inventory-general-info": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-general-info/-/frontend-components-inventory-general-info-3.4.0.tgz",
-            "integrity": "sha512-AJAL5sfSDCRK29e1tO1EoQ94Q65Uh0/Wwd39S/JE8LrlkO6s+17hoz16a1PeOtBFppu7QROOA1hcMQqjBUlnLg==",
-            "requires": {
-                "@redhat-cloud-services/frontend-components": ">=3.0.0",
-                "@redhat-cloud-services/frontend-components-inventory": "*",
-                "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
-                "@redhat-cloud-services/host-inventory-client": "1.0.91",
-                "abortcontroller-polyfill": "^1.7.1",
-                "prop-types": "^15.7.2",
-                "react-redux": "^7.2.4",
-                "redux": "^4.1.0"
-            },
-            "dependencies": {
-                "@redhat-cloud-services/host-inventory-client": {
-                    "version": "1.0.91",
-                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.91.tgz",
-                    "integrity": "sha512-UeDEOrhxs8ztJh2qzw0isIDWN1AHxV7Aybnoe2l0T9fg1uiFP4B2wmuE2J5FUv1TCt3V2Op7cW+vqMA4VC/t0A==",
-                    "requires": {
-                        "axios": "^0.21.1"
-                    }
-                },
-                "axios": {
-                    "version": "0.21.4",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-                    "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-                    "requires": {
-                        "follow-redirects": "^1.14.0"
-                    }
-                }
-            }
-        },
         "@redhat-cloud-services/frontend-components-notifications": {
             "version": "3.2.12",
             "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.12.tgz",
@@ -26194,11 +26048,6 @@
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "devOptional": true
-        },
-        "abortcontroller-polyfill": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
-            "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
         },
         "accepts": {
             "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "@patternfly/react-table": "^4.111.33",
         "@patternfly/react-tokens": "^4.93.10",
         "@redhat-cloud-services/frontend-components": "^3.9.20",
-        "@redhat-cloud-services/frontend-components-inventory-general-info": "^3.4.0",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
         "@redhat-cloud-services/frontend-components-utilities": "^3.3.3",
         "@redhat-cloud-services/host-inventory-client": "^1.0.111",

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -20,12 +20,12 @@ import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { deviceDetail } from '../../store/deviceDetail';
 import { RegistryContext } from '../../store';
-import systemProfileStore from '@redhat-cloud-services/frontend-components-inventory-general-info/redux';
 import DeviceDetailTabs from './DeviceDetailTabs';
 import { getDeviceHasUpdate, getInventory } from '../../api/devices';
 import Status, { getDeviceStatus } from '../../components/Status';
 import useApi from '../../hooks/useApi';
 import RetryUpdatePopover from '../Devices/RetryUpdatePopover';
+import { useLoadModule } from '@scalprum/react-core';
 
 const UpdateDeviceModal = React.lazy(() =>
   import(
@@ -34,6 +34,14 @@ const UpdateDeviceModal = React.lazy(() =>
 );
 
 const DeviceDetail = () => {
+  const [{ default: systemProfileStore }] = useLoadModule(
+    {
+      appName: 'inventory',
+      scope: 'inventory',
+      module: './systemProfileStore',
+    },
+    {}
+  );
   const [imageId, setImageId] = useState(null);
   const { getRegistry } = useContext(RegistryContext);
   const { deviceId } = useParams();
@@ -98,112 +106,114 @@ const DeviceDetail = () => {
     })();
   }, [entity, reload]);
 
-  return (
-    <>
-      <DetailWrapper
-        hideInvLink
-        showTags
-        onLoad={({ mergeWithDetail }) => {
-          getRegistry().register({
-            systemProfileStore,
-            ...mergeWithDetail(deviceDetail),
-          });
-        }}
-      >
-        <PageHeader>
-          <Breadcrumb ouiaId="systems-list">
-            <BreadcrumbItem>
-              <Link to="/inventory">Systems</Link>
-            </BreadcrumbItem>
-            <BreadcrumbItem isActive>
-              <div className="ins-c-inventory__detail--breadcrumb-name">
-                {entity?.display_name || <Skeleton size={SkeletonSize.xs} />}
-              </div>
-            </BreadcrumbItem>
-          </Breadcrumb>
-          <InventoryDetailHead
-            fallback=""
-            actions={[
-              {
-                title: 'Update',
-                isDisabled:
-                  imageData?.UpdateTransactions?.[0]?.Status === 'BUILDING' ||
-                  imageData?.UpdateTransactions?.[0]?.Status === 'CREATED' ||
-                  !imageData?.ImageInfo?.UpdatesAvailable?.length > 0 ||
-                  !updateModal.imageSetId,
-                onClick: () => {
-                  setUpdateModal((prevState) => ({
-                    ...prevState,
-                    isOpen: true,
-                  }));
-                },
+  return systemProfileStore ? (
+    <DetailWrapper
+      hideInvLink
+      showTags
+      onLoad={({ mergeWithDetail }) => {
+        getRegistry().register({
+          systemProfileStore,
+          ...mergeWithDetail(deviceDetail),
+        });
+      }}
+    >
+      <PageHeader>
+        <Breadcrumb ouiaId="systems-list">
+          <BreadcrumbItem>
+            <Link to="/inventory">Systems</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>
+            <div className="ins-c-inventory__detail--breadcrumb-name">
+              {entity?.display_name || <Skeleton size={SkeletonSize.xs} />}
+            </div>
+          </BreadcrumbItem>
+        </Breadcrumb>
+        <InventoryDetailHead
+          fallback=""
+          actions={[
+            {
+              title: 'Update',
+              isDisabled:
+                imageData?.UpdateTransactions?.[0]?.Status === 'BUILDING' ||
+                imageData?.UpdateTransactions?.[0]?.Status === 'CREATED' ||
+                !imageData?.ImageInfo?.UpdatesAvailable?.length > 0 ||
+                !updateModal.imageSetId,
+              onClick: () => {
+                setUpdateModal((prevState) => ({
+                  ...prevState,
+                  isOpen: true,
+                }));
               },
-            ]}
-            hideBack
-            hideInvDrawer
-            inventoryId={deviceId}
-          />
+            },
+          ]}
+          hideBack
+          hideInvDrawer
+          inventoryId={deviceId}
+        />
 
-          {isDeviceStatusLoading ? (
-            <Skeleton size={SkeletonSize.xs} />
-          ) : deviceStatus === 'error' || deviceStatus === 'unresponsive' ? (
-            <RetryUpdatePopover
-              lastSeen={lastSeen}
-              device={deviceView}
-              position={'right'}
-              fetchDevices={fetchDeviceData}
-            >
-              <Status
-                type={
-                  deviceStatus === 'error'
-                    ? 'errorWithExclamationCircle'
-                    : deviceStatus
-                }
-                isLink={true}
-                isLabel={true}
-                className="pf-u-mt-sm cursor-pointer"
-              />
-            </RetryUpdatePopover>
-          ) : (
-            <Status type={deviceStatus} isLabel={true} className="pf-u-mt-sm" />
-          )}
-        </PageHeader>
-        <Grid gutter="md">
-          <GridItem span={12}>
-            <DeviceDetailTabs
-              systemProfile={imageData}
-              imageId={imageId}
-              setUpdateModal={setUpdateModal}
-              setReload={setReload}
-            />
-          </GridItem>
-        </Grid>
-        {updateModal.isOpen && (
-          <Suspense
-            fallback={
-              <Bullseye>
-                <Spinner />
-              </Bullseye>
-            }
+        {isDeviceStatusLoading ? (
+          <Skeleton size={SkeletonSize.xs} />
+        ) : deviceStatus === 'error' || deviceStatus === 'unresponsive' ? (
+          <RetryUpdatePopover
+            lastSeen={lastSeen}
+            device={deviceView}
+            position={'right'}
+            fetchDevices={fetchDeviceData}
           >
-            <UpdateDeviceModal
-              navigateBack={() => {
-                history.push({ pathname: history.location.pathname });
-                setUpdateModal((prevState) => {
-                  return {
-                    ...prevState,
-                    isOpen: false,
-                  };
-                });
-              }}
-              setUpdateModal={setUpdateModal}
-              updateModal={updateModal}
-              refreshTable={() => setReload(true)}
+            <Status
+              type={
+                deviceStatus === 'error'
+                  ? 'errorWithExclamationCircle'
+                  : deviceStatus
+              }
+              isLink={true}
+              isLabel={true}
+              className="pf-u-mt-sm cursor-pointer"
             />
-          </Suspense>
+          </RetryUpdatePopover>
+        ) : (
+          <Status type={deviceStatus} isLabel={true} className="pf-u-mt-sm" />
         )}
-      </DetailWrapper>
-    </>
+      </PageHeader>
+      <Grid gutter="md">
+        <GridItem span={12}>
+          <DeviceDetailTabs
+            systemProfile={imageData}
+            imageId={imageId}
+            setUpdateModal={setUpdateModal}
+            setReload={setReload}
+          />
+        </GridItem>
+      </Grid>
+      {updateModal.isOpen && (
+        <Suspense
+          fallback={
+            <Bullseye>
+              <Spinner />
+            </Bullseye>
+          }
+        >
+          <UpdateDeviceModal
+            navigateBack={() => {
+              history.push({ pathname: history.location.pathname });
+              setUpdateModal((prevState) => {
+                return {
+                  ...prevState,
+                  isOpen: false,
+                };
+              });
+            }}
+            setUpdateModal={setUpdateModal}
+            updateModal={updateModal}
+            refreshTable={() => setReload(true)}
+          />
+        </Suspense>
+      )}
+    </DetailWrapper>
+  ) : (
+    <Bullseye>
+      <Spinner />
+    </Bullseye>
   );
 };
 

--- a/src/components/ImageInformationCard.js
+++ b/src/components/ImageInformationCard.js
@@ -1,13 +1,23 @@
-import React, { useEffect, useState } from 'react';
-import LoadingCard from '@redhat-cloud-services/frontend-components-inventory-general-info/LoadingCard';
+import React, { Suspense, useEffect, useState } from 'react';
 import { getImageDataOnDevice } from '../api/images';
 import { routes as paths } from '../constants/routeMapper';
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import {
   Skeleton,
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
+import CmpLoader from './CmpLoader';
+
+const LoadingCard = (props) => (
+  <AsyncComponent
+    appName="inventory"
+    module="./LoadingCard"
+    fallback={<CmpLoader numberOfRows={5} />}
+    {...props}
+  />
+);
 
 const ImageInformationCard = () => {
   const deviceId = useSelector(
@@ -15,8 +25,8 @@ const ImageInformationCard = () => {
   );
   const [isImageInfoLoading, setIsImageInfoLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
-
   const [imageData, setImageData] = useState(null);
+
   useEffect(() => {
     (async () => {
       try {
@@ -30,72 +40,74 @@ const ImageInformationCard = () => {
   }, []);
 
   return (
-    <LoadingCard
-      title="Image information"
-      isLoading={false}
-      items={[
-        {
-          title: 'Running image',
-          value: isImageInfoLoading ? (
-            <Skeleton size={SkeletonSize.sm} />
-          ) : imageData ? (
-            <Link
-              to={`${paths['manage-images']}/${imageData?.Image?.ImageSetID}/details`}
-            >
-              {imageData?.Image?.Name}
-            </Link>
-          ) : (
-            'unavailable'
-          ),
-        },
-        {
-          title: 'Running version',
-          value: isImageInfoLoading ? (
-            <Skeleton size={SkeletonSize.sm} />
-          ) : imageData ? (
-            <Link
-              to={`${paths['manage-images']}/${imageData?.Image?.ImageSetID}/versions/${imageData?.Image?.ID}/details`}
-            >
-              {imageData?.Image?.Version}
-            </Link>
-          ) : (
-            'unavailable'
-          ),
-        },
-        {
-          title: 'Target version',
-          value: isImageInfoLoading ? (
-            <Skeleton size={SkeletonSize.sm} />
-          ) : imageData?.UpdatesAvailable ? (
-            <Link
-              to={`${paths['manage-images']}/${imageData?.UpdatesAvailable[0]?.Image?.ImageSetID}/versions/${imageData?.UpdatesAvailable[0]?.Image?.ID}/details`}
-            >
-              {imageData?.UpdatesAvailable[0]?.Image?.Version}
-            </Link>
-          ) : hasError ? (
-            'unavailable'
-          ) : (
-            'Same as running'
-          ),
-        },
-        {
-          title: 'Rollback version',
-          value: isImageInfoLoading ? (
-            <Skeleton size={SkeletonSize.sm} />
-          ) : imageData?.RollbackImage?.ID ? (
-            <Link
-              to={`${paths['manage-images']}/${imageData?.RollbackImage?.ImageSetID}/versions/${imageData?.RollbackImage?.ID}/details`}
-            >
-              {imageData?.RollbackImage?.Version}
-            </Link>
-          ) : hasError ? (
-            'unavailable'
-          ) : (
-            'None'
-          ),
-        },
-      ]}
-    />
+    <Suspense fallback="">
+      <LoadingCard
+        title="Image information"
+        isLoading={false}
+        items={[
+          {
+            title: 'Running image',
+            value: isImageInfoLoading ? (
+              <Skeleton size={SkeletonSize.sm} />
+            ) : imageData ? (
+              <Link
+                to={`${paths['manage-images']}/${imageData?.Image?.ImageSetID}/details`}
+              >
+                {imageData?.Image?.Name}
+              </Link>
+            ) : (
+              'unavailable'
+            ),
+          },
+          {
+            title: 'Running version',
+            value: isImageInfoLoading ? (
+              <Skeleton size={SkeletonSize.sm} />
+            ) : imageData ? (
+              <Link
+                to={`${paths['manage-images']}/${imageData?.Image?.ImageSetID}/versions/${imageData?.Image?.ID}/details`}
+              >
+                {imageData?.Image?.Version}
+              </Link>
+            ) : (
+              'unavailable'
+            ),
+          },
+          {
+            title: 'Target version',
+            value: isImageInfoLoading ? (
+              <Skeleton size={SkeletonSize.sm} />
+            ) : imageData?.UpdatesAvailable ? (
+              <Link
+                to={`${paths['manage-images']}/${imageData?.UpdatesAvailable[0]?.Image?.ImageSetID}/versions/${imageData?.UpdatesAvailable[0]?.Image?.ID}/details`}
+              >
+                {imageData?.UpdatesAvailable[0]?.Image?.Version}
+              </Link>
+            ) : hasError ? (
+              'unavailable'
+            ) : (
+              'Same as running'
+            ),
+          },
+          {
+            title: 'Rollback version',
+            value: isImageInfoLoading ? (
+              <Skeleton size={SkeletonSize.sm} />
+            ) : imageData?.RollbackImage?.ID ? (
+              <Link
+                to={`${paths['manage-images']}/${imageData?.RollbackImage?.ImageSetID}/versions/${imageData?.RollbackImage?.ID}/details`}
+              >
+                {imageData?.RollbackImage?.Version}
+              </Link>
+            ) : hasError ? (
+              'unavailable'
+            ) : (
+              'None'
+            ),
+          },
+        ]}
+      />
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
# Description

This PR removes the deprecated package `@redhat-cloud-services/frontend-components-inventory-general-info`, and uses the federated modules provided by insights-inventory-frontend instead.

This impacts only the system details page, specifically the system details header along the top and the "Image Information" card. All system details should still display correctly after this change.

Fixes # (THEEDGE-2497)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted