### PR TITLE
Fix display of button and popover in image wizard custom packages step

### DIFF
--- a/src/Routes/ImageManager/steps/customPackage.js
+++ b/src/Routes/ImageManager/steps/customPackage.js
@@ -71,20 +71,20 @@ const CustomPackageLabel = () => {
             headerContent="Custom Repositories"
             bodyContent={
               <Stack>
-                {addedRepos.map((repo) => (
-                  <StackItem key={repo}>
-                    <Text>{repo.name}</Text>
+                {addedRepos.map(({ name }) => (
+                  <StackItem key={name}>
+                    <Text>{name}</Text>
                   </StackItem>
                 ))}
               </Stack>
             }
           >
             <Button variant="link" isInline>
-              {addedRepos.length} custom repositories
-            </Button>{' '}
-            to your
-          </Popover>
-          <b> {releaseName}</b> image.
+              {addedRepos.length} custom{' '}
+              {addedRepos.length === 1 ? 'repository' : 'repositories'}
+            </Button>
+          </Popover>{' '}
+          to your <b>{releaseName}</b> image.
         </Text>
       </TextContent>
       {addedRepos.length === 0 && customPackages.length > 0 ? (


### PR DESCRIPTION
# Description

This PR fixes the display of the Custom packages step while creating or updating an image, which was broken after https://github.com/RedHatInsights/edge-frontend/pull/591

Currently, when on the Custom packages step with linked custom repos, the user sees, for example,

"Add packages from to your Red Hat Enterprise Linux (RHEL) 9.0 image."

With this fix,

"Add packages from 1 custom repository to your Red Hat Enterprise Linux (RHEL) 9.0 image."
or
"Add packages from X custom repositories to your Red Hat Enterprise Linux (RHEL) 9.0 image."

with "1 custom repository" or "X custom repositories" a link-type button that correctly displays the list of selected custom repos in a popover when clicked.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted