### PR TITLE
Use image-sets view API call in Vulnerability tab

### DIFF
--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -63,11 +63,13 @@ const VulnerabilityTab = ({
       if (!deviceData) {
         return;
       }
-      const id = {
-        id: deviceData?.ImageInfo?.Image?.ImageSetID,
+      // Use view API to get current image set status
+      const params = {
+        id: 'view',
+        q: { id: deviceData?.ImageInfo?.Image?.ImageSetID },
       };
-      const newImageData = await getImageSet(id);
-      setNewImageStatus(newImageData?.Data?.images?.[0]?.image?.Status);
+      const resp = await getImageSet(params);
+      setNewImageStatus(resp?.data?.[0]?.Status);
     })();
   }, [deviceData]);
 


### PR DESCRIPTION
# Description

This PR fixes API timeouts on the system details page by replacing API calls to `/image-sets/{id}` with `/image-sets/view?id={id}`. The API is only used to get the current image set status, so using the lighter-weight view API resolves these errors.

Fixes # (THEEDGE-2852)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted