### PR TITLE
Add RHEL 9.1 to distributionMapper

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -66,6 +66,7 @@ export const distributionMapper = {
   'rhel-86': 'RHEL 8.6',
   'rhel-87': 'RHEL 8.7',
   'rhel-90': 'RHEL 9.0',
+  'rhel-91': 'RHEL 9.1',
 };
 
 export const releaseMapper = {


### PR DESCRIPTION
# Description

This PR adds RHEL 9.1 to the list of known releases, so that "RHEL 9.1" will display instead of "Unknown" in places like the image set details or image version details pages.

Fixes # (THEEDGE-2853)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted