### PR TITLE
THEEDGE-2466 - Breadcrumbs aren't correct when going from groups to devices 

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -70,6 +70,7 @@ export const Routes = () => {
       <Switch>
         <Route exact path={paths.groups} component={Groups} />
         <Route exact path={paths['groups-detail']} component={GroupsDetail} />
+
         {/* <Route path={paths['device-detail']} component={DeviceDetail} /> */}
         {/* <Route path={paths.canaries} component={Canaries} /> */}
         <Route exact path={paths['fleet-management']} component={Groups} />
@@ -77,6 +78,11 @@ export const Routes = () => {
           exact
           path={paths['fleet-management-detail']}
           component={GroupsDetail}
+        />
+        <Route
+          exact
+          path={paths['fleet-management-system-detail']}
+          component={DeviceDetail}
         />
         <Route exact path={paths['inventory']} component={Inventory} />
         <Route path={paths['inventory-detail']} component={DeviceDetail} />

--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { RegistryContext } from '../../store';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { Alert, Button } from '@patternfly/react-core';
@@ -43,7 +43,7 @@ const VulnerabilityTab = ({
   imageId,
   setReload,
 }) => {
-  const { params } = useRouteMatch('/inventory/:deviceId');
+  const { deviceId } = useParams();
   const { getRegistry } = useContext(RegistryContext);
   const [updateCveModal, setUpdateCveModal] = useState({
     isOpen: false,
@@ -165,7 +165,7 @@ const VulnerabilityTab = ({
           module="./SystemDetail"
           getRegistry={getRegistry}
           customIntlProvider
-          entity={{ id: params.deviceId }}
+          entity={{ id: deviceId }}
           canSelect={false}
           canEditPairStatus={false}
           canManageColumns={false}

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -2,12 +2,11 @@ import React from 'react';
 import GeneralTable from '../../components/general-table/GeneralTable';
 import PropTypes from 'prop-types';
 import { routes as paths } from '../../constants/routeMapper';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { cellWidth } from '@patternfly/react-table';
 import { Tooltip } from '@patternfly/react-core';
 import CustomEmptyState from '../../components/Empty';
-import { useHistory } from 'react-router-dom';
 import { emptyStateNoFliters } from '../../utils';
 import DeviceStatus, { getDeviceStatus } from '../../components/Status';
 import RetryUpdatePopover from './RetryUpdatePopover';
@@ -62,10 +61,9 @@ const columnNames = [
   },
 ];
 
-const createRows = (devices, hasLinks, fetchDevices) => {
+const createRows = (devices, hasLinks, fetchDevices, deviceLinkBase) => {
   return devices?.map((device) => {
     let { DeviceName, DeviceGroups } = device;
-
     const {
       DeviceID,
       DeviceUUID,
@@ -132,7 +130,13 @@ const createRows = (devices, hasLinks, fetchDevices) => {
       cells: [
         {
           title: hasLinks ? (
-            <Link to={`${paths['inventory']}/${DeviceUUID}`}>{DeviceName}</Link>
+            <Link
+              to={{
+                pathname: `${deviceLinkBase}/${DeviceUUID}`,
+              }}
+            >
+              {DeviceName}
+            </Link>
           ) : (
             DeviceName
           ),
@@ -219,6 +223,12 @@ const DeviceTable = ({
   const canBeAdded = setIsAddModalOpen;
   const canBeUpdated = isSystemsView;
   const history = useHistory();
+
+  // Create base URL path for system detail link
+  let deviceBaseUrl = history.location.pathname;
+  if (deviceBaseUrl !== paths.inventory) {
+    deviceBaseUrl = deviceBaseUrl + '/systems';
+  }
 
   const actionResolver = (rowData) => {
     const actions = [];
@@ -335,7 +345,8 @@ const DeviceTable = ({
           rows={createRows(
             data || [],
             isAddSystemsView || isSystemsView,
-            fetchDevices
+            fetchDevices,
+            deviceBaseUrl
           )}
           actionResolver={actionResolver}
           defaultSort={{ index: 3, direction: 'desc' }}

--- a/src/constants/routeMapper.js
+++ b/src/constants/routeMapper.js
@@ -5,6 +5,8 @@ export const routes = {
   canaries: '/canaries',
   'fleet-management': '/fleet-management',
   'fleet-management-detail': '/fleet-management/:groupId',
+  'fleet-management-system-detail':
+    '/fleet-management/:groupId/systems/:deviceId',
   inventory: '/inventory',
   'inventory-detail': '/inventory/:deviceId',
   'manage-images': '/manage-images',


### PR DESCRIPTION
# Description

When clicking on a system from a group's details page, the system details page is now a distinct URL path (`/fleet-management/:groupId/systems/:deviceId`), and the breadcrumbs on the system details page  show "Groups > {Group name} > {System name}" instead of "Systems > {System name}".

Fixes # (THEEDGE-2466)


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [ ] Tests update

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted