### PR TITLE
Move update system page to a new route

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,59 +3,57 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import React, { Suspense } from 'react';
 import { routes as paths } from './constants/routeMapper';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-// const Groups = React.lazy(() =>
-//   import(/* webpackChunkName: "GroupsPage" */ './Routes/Groups/Groups')
-// );
-// const GroupsDetail = React.lazy(() =>
-//   import(
-//     /* webpackChunkName: "GroupsDetailPage" */ './Routes/GroupsDetail/GroupsDetail'
-//   )
-// );
 
 const DeviceDetail = React.lazy(() =>
   import(
-    /* webpackChunkName: "GroupsDetailPage" */ './Routes/DeviceDetail/DeviceDetail'
+    /* webpackChunkName: "DeviceDetail" */ './Routes/DeviceDetail/DeviceDetail'
   )
 );
 
 // const Canaries = React.lazy(() =>
 //   import(
-//     /* webpackChunkName: "GroupsDetailPage" */ './Routes/Canaries/Canaries'
+//     /* webpackChunkName: "Canaries" */ './Routes/Canaries/Canaries'
 //   )
 // );
 
 const Groups = React.lazy(() =>
-  import(/* webpackChunkName: "GroupsDetailPage" */ './Routes/Groups/Groups')
+  import(/* webpackChunkName: "Groups" */ './Routes/Groups/Groups')
 );
 
 const GroupsDetail = React.lazy(() =>
   import(
-    /* webpackChunkName: "GroupsDetailPage" */ './Routes/GroupsDetail/GroupsDetail'
+    /* webpackChunkName: "GroupsDetail" */ './Routes/GroupsDetail/GroupsDetail'
   )
 );
 
 const Inventory = React.lazy(() =>
-  import(
-    /* webpackChunkName: "GroupsDetailPage" */ './Routes/Devices/Inventory'
-  )
+  import(/* webpackChunkName: "Inventory" */ './Routes/Devices/Inventory')
+);
+
+const UpdateSystem = React.lazy(() =>
+  import(/* webpackChunkName: "UpdateSystem" */ './Routes/Devices/UpdateSystem')
 );
 
 const Images = React.lazy(() =>
-  import(
-    /* webpackChunkName: "GroupsDetailPage" */ './Routes/ImageManager/Images'
-  )
+  import(/* webpackChunkName: "Images" */ './Routes/ImageManager/Images')
 );
 
 const ImageDetail = React.lazy(() =>
-  import('./Routes/ImageManagerDetail/ImageDetail')
+  import(
+    /* webpackChunkName: "ImageDetail" */ './Routes/ImageManagerDetail/ImageDetail'
+  )
 );
 
 const Repositories = React.lazy(() =>
-  import('./Routes/Repositories/Repositories')
+  import(
+    /* webpackChunkName: "Repositories" */ './Routes/Repositories/Repositories'
+  )
 );
 
 const LearningResources = React.lazy(() =>
-  import('./Routes/LearningResources/LearningResources')
+  import(
+    /* webpackChunkName: "LearningResources" */ './Routes/LearningResources/LearningResources'
+  )
 );
 
 export const Routes = () => {
@@ -79,6 +77,11 @@ export const Routes = () => {
           component={GroupsDetail}
         />
         <Route exact path={paths['inventory']} component={Inventory} />
+        <Route
+          exact
+          path={paths['inventory-detail-update']}
+          component={UpdateSystem}
+        />
         <Route path={paths['inventory-detail']} component={DeviceDetail} />
         <Route
           path={paths['manage-images-detail-version']}

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -21,7 +21,7 @@ import { useSelector } from 'react-redux';
 import { deviceDetail } from '../../store/deviceDetail';
 import { RegistryContext } from '../../store';
 import DeviceDetailTabs from './DeviceDetailTabs';
-import { getDeviceHasUpdate, getInventory } from '../../api/devices';
+import { getDevice, getInventory } from '../../api/devices';
 import Status, { getDeviceStatus } from '../../components/Status';
 import useApi from '../../hooks/useApi';
 import RetryUpdatePopover from '../Devices/RetryUpdatePopover';
@@ -29,7 +29,7 @@ import { useLoadModule } from '@scalprum/react-core';
 
 const UpdateDeviceModal = React.lazy(() =>
   import(
-    /* webpackChunkName: "CreateImageWizard" */ '../Devices/UpdateDeviceModal'
+    /* webpackChunkName: "UpdateDeviceModal" */ '../Devices/UpdateDeviceModal'
   )
 );
 
@@ -88,7 +88,7 @@ const DeviceDetail = () => {
       if (!entity?.display_name) {
         return;
       }
-      const image_data = await getDeviceHasUpdate(deviceId);
+      const image_data = await getDevice(deviceId);
       setImageData(image_data);
       setIsDeviceStatusLoading(false);
       setUpdateModal((prevState) => ({

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -202,7 +202,6 @@ const DeviceTable = ({
   count,
   isLoading,
   hasError,
-  setUpdatePage,
   kebabItems,
   setRemoveModal,
   setIsAddModalOpen,
@@ -263,19 +262,8 @@ const DeviceTable = ({
       actions.push({
         title: 'Update',
         onClick: (_event, _rowId, rowData) => {
-          setUpdatePage((prevState) => {
-            return {
-              ...prevState,
-              isOpen: true,
-              deviceData: [
-                {
-                  id: rowData.rowInfo.id,
-                  display_name: rowData.rowInfo.display_name,
-                  deviceStatus: rowData.rowInfo.deviceStatus,
-                },
-              ],
-              imageData: { imageName: rowData.rowInfo.imageName },
-            };
+          history.push({
+            pathname: `${paths['inventory']}/${rowData.rowInfo.id}/update`,
           });
         },
       });
@@ -388,7 +376,6 @@ DeviceTable.propTypes = {
   count: PropTypes.number,
   isLoading: PropTypes.bool,
   hasError: PropTypes.bool,
-  setUpdatePage: PropTypes.func,
   handleSingleDeviceRemoval: PropTypes.func,
   kebabItems: PropTypes.array,
   setRemoveModal: PropTypes.func,

--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -8,18 +8,10 @@ import DeviceTable from './DeviceTable';
 import AddDeviceModal from './AddDeviceModal';
 import RemoveDeviceModal from './RemoveDeviceModal';
 import CreateGroupModal from '../Groups/CreateGroupModal';
-import UpdateSystem from './UpdateSystem';
 import useApi from '../../hooks/useApi';
 import { getInventory } from '../../api/devices';
-import { Link, useHistory } from 'react-router-dom';
-import {
-  TextContent,
-  Text,
-  Breadcrumb,
-  BreadcrumbItem,
-  Bullseye,
-  Spinner,
-} from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
 const UpdateDeviceModal = React.lazy(() =>
   import(/* webpackChunkName: "UpdateDeviceModal" */ './UpdateDeviceModal')
@@ -39,12 +31,6 @@ const Inventory = () => {
   const [isRowSelected, setIsRowSelected] = useState(false);
   const [hasModalSubmitted, setHasModalSubmitted] = useState(false);
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
-
-  const [updatePage, setUpdatePage] = useState({
-    isOpen: false,
-    deviceData: null,
-    imageData: null,
-  });
 
   const [updateModal, setUpdateModal] = useState({
     isOpen: false,
@@ -109,72 +95,41 @@ const Inventory = () => {
   return (
     <>
       <PageHeader className="pf-m-light">
-        {updatePage.isOpen && (
-          <Breadcrumb>
-            <BreadcrumbItem
-              onClick={() =>
-                setUpdatePage((prev) => ({ ...prev, isOpen: false }))
-              }
-            >
-              <Link to="/inventory">Systems</Link>
-            </BreadcrumbItem>
-            <BreadcrumbItem>Update</BreadcrumbItem>
-          </Breadcrumb>
-        )}
-        <PageHeaderTitle title={updatePage.isOpen ? 'Update' : 'Systems'} />
-        {updatePage.isOpen && (
-          <TextContent className="pf-u-mt-md">
-            <Text>
-              Update <strong>{updatePage?.deviceData[0]?.display_name}</strong>{' '}
-              to a newer version of{' '}
-              <strong>{updatePage?.imageData?.imageName}</strong> by selecting a
-              new version from the table below.
-            </Text>
-          </TextContent>
-        )}
+        <PageHeaderTitle title="Systems" />
       </PageHeader>
       <Main className="edge-devices">
-        {updatePage.isOpen ? (
-          <UpdateSystem
-            setUpdatePage={setUpdatePage}
-            systemId={updatePage.deviceData[0].id}
-            refreshTable={reloadData}
-          />
-        ) : (
-          <DeviceTable
-            isSystemsView={true}
-            data={data?.data?.devices}
-            count={data?.count}
-            isLoading={isLoading}
-            hasError={hasError}
-            setUpdatePage={setUpdatePage}
-            setUpdateModal={setUpdateModal}
-            updateModal={updateModal}
-            handleAddDevicesToGroup={handleAddDevicesToGroup}
-            handleRemoveDevicesFromGroup={handleRemoveDevicesFromGroup}
-            handleUpdateSelected={handleUpdateSelected}
-            hasCheckbox={true}
-            selectedItems={setCheckedDeviceIds}
-            selectedItemsUpdateable={canBeUpdated()}
-            kebabItems={[
-              {
-                isDisabled: !(checkedDeviceIds.length > 0),
-                title: 'Add to group',
-                onClick: () =>
-                  handleAddDevicesToGroup(
-                    checkedDeviceIds.map((device) => ({
-                      ID: device.deviceID,
-                      name: device.display_name,
-                    })),
-                    false
-                  ),
-              },
-            ]}
-            hasModalSubmitted={hasModalSubmitted}
-            setHasModalSubmitted={setHasModalSubmitted}
-            fetchDevices={fetchDevices}
-          />
-        )}
+        <DeviceTable
+          isSystemsView={true}
+          data={data?.data?.devices}
+          count={data?.count}
+          isLoading={isLoading}
+          hasError={hasError}
+          setUpdateModal={setUpdateModal}
+          updateModal={updateModal}
+          handleAddDevicesToGroup={handleAddDevicesToGroup}
+          handleRemoveDevicesFromGroup={handleRemoveDevicesFromGroup}
+          handleUpdateSelected={handleUpdateSelected}
+          hasCheckbox={true}
+          selectedItems={setCheckedDeviceIds}
+          selectedItemsUpdateable={canBeUpdated()}
+          kebabItems={[
+            {
+              isDisabled: !(checkedDeviceIds.length > 0),
+              title: 'Add to group',
+              onClick: () =>
+                handleAddDevicesToGroup(
+                  checkedDeviceIds.map((device) => ({
+                    ID: device.deviceID,
+                    name: device.display_name,
+                  })),
+                  false
+                ),
+            },
+          ]}
+          hasModalSubmitted={hasModalSubmitted}
+          setHasModalSubmitted={setHasModalSubmitted}
+          fetchDevices={fetchDevices}
+        />
       </Main>
       {updateModal.isOpen && (
         <Suspense

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -4,8 +4,10 @@ import { headerCol } from '@patternfly/react-table';
 import { Button, Divider } from '@patternfly/react-core';
 import { updateSystem } from '../../api/devices';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
 import apiWithToast from '../../utils/apiWithToast';
 import PropTypes from 'prop-types';
+import { routes as paths } from '../../constants/routeMapper';
 
 const filters = [
   { label: 'Version', type: 'text' },
@@ -28,16 +30,11 @@ const columns = [
   { title: 'Created' },
 ];
 
-const UpdateVersionTable = ({
-  data,
-  setUpdatePage,
-  refreshTable,
-  isLoading,
-  hasError,
-}) => {
+const UpdateVersionTable = ({ data, isLoading, hasError }) => {
   const [selectedVersion, setSelectedVersion] = useState(null);
   const [selectedCommitID, setSelectedCommitID] = useState(null);
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const buildRows = data?.map((rowData) => {
     const {
@@ -94,16 +91,10 @@ const UpdateVersionTable = ({
       statusMessages
     );
     handleClose();
-    refreshTable ? refreshTable() : null;
   };
 
   const handleClose = () => {
-    setUpdatePage((prevState) => {
-      return {
-        ...prevState,
-        isOpen: false,
-      };
-    });
+    history.push(paths['inventory']);
   };
 
   return (
@@ -166,8 +157,6 @@ const UpdateVersionTable = ({
 
 UpdateVersionTable.propTypes = {
   data: PropTypes.array,
-  setUpdatePage: PropTypes.func,
-  refreshTable: PropTypes.func,
   isLoading: PropTypes.bool,
   hasError: PropTypes.bool,
 };

--- a/src/Routes/Groups/GroupTable.js
+++ b/src/Routes/Groups/GroupTable.js
@@ -6,7 +6,9 @@ import { routes as paths } from '../../constants/routeMapper';
 import { Bullseye, Spinner, Tooltip } from '@patternfly/react-core';
 
 const UpdateDeviceModal = React.lazy(() =>
-  import('../Devices/UpdateDeviceModal')
+  import(
+    /* webpackChunkName: "UpdateDeviceModal" */ '../Devices/UpdateDeviceModal'
+  )
 );
 
 const filters = [

--- a/src/Routes/GroupsDetail/GroupsDetail.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.js
@@ -43,7 +43,9 @@ import DeleteGroupModal from '../Groups/DeleteGroupModal';
 import RenameGroupModal from '../Groups/RenameGroupModal';
 
 const UpdateDeviceModal = React.lazy(() =>
-  import('../Devices/UpdateDeviceModal')
+  import(
+    /* webpackChunkName: "UpdateDeviceModal" */ '../Devices/UpdateDeviceModal'
+  )
 );
 
 const GroupsDetail = () => {
@@ -275,7 +277,6 @@ const GroupsDetail = () => {
             selectedItems={getDeviceIds}
             setRemoveModal={setRemoveModal}
             setIsAddModalOpen={setIsAddModalOpen}
-            setUpdatePage={setUpdateModal}
             hasModalSubmitted={hasModalSubmitted}
             setHasModalSubmitted={setHasModalSubmitted}
             fetchDevices={fetchDevices}

--- a/src/api/devices/index.js
+++ b/src/api/devices/index.js
@@ -6,13 +6,8 @@ export const getInventory = ({ query }) => {
   return instance.get(`${EDGE_API}/devices/devicesview?${q}`);
 };
 
-export const getDeviceHasUpdate = async (id) => {
-  try {
-    return await instance.get(`${EDGE_API}/devices/${id}`);
-  } catch (err) {
-    // temp error solution
-    console.log('');
-  }
+export const getDevice = (id) => {
+  return instance.get(`${EDGE_API}/devices/${id}`);
 };
 
 export const updateSystem = async (payload) => {

--- a/src/components/DeviceDetail.js
+++ b/src/components/DeviceDetail.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense } from 'react';
 import { useStore, useSelector } from 'react-redux';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Tooltip } from '@patternfly/react-core';
@@ -61,7 +61,11 @@ const InfrastructureCard = (props) => (
   />
 );
 
-const ImageInformationCard = lazy(() => import('./ImageInformationCard'));
+const ImageInformationCard = React.lazy(() =>
+  import(
+    /* webpackChunkName: "ImageInformationCard" */ './ImageInformationCard'
+  )
+);
 
 const InfrastructureCardWrapper = (props) => {
   const store = useStore();

--- a/src/constants/routeMapper.js
+++ b/src/constants/routeMapper.js
@@ -7,6 +7,7 @@ export const routes = {
   'fleet-management-detail': '/fleet-management/:groupId',
   inventory: '/inventory',
   'inventory-detail': '/inventory/:deviceId',
+  'inventory-detail-update': '/inventory/:deviceId/update',
   'manage-images': '/manage-images',
   'manage-images-detail': '/manage-images/:imageId',
   'manage-images-detail-version':


### PR DESCRIPTION
# Description

This PR moves the new non-modal system update page to its own route, `/inventory/:deviceId/update`. The functionality is unchanged, but now clicking on `Systems` in the left navigation menu will successfully navigate back to the inventory page. Previously, nothing happened when clicking on it.

There are two other fixes included:
- Clicking on `Update` in the row-level kebab for a system in the group details page just gave a spinner, and the modal never loaded.
- The webpack chunk names for lazy-imported components were all the same. Names are now unique per component, so that the browser only has to download the code it needs for the given route or modal.

Fixes # (THEEDGE-2850, THEEDGE-2895, THEEDGE-2897)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted