### PR TITLE
Remove unused query params from getImageSetView

### DIFF
--- a/src/api/images/index.js
+++ b/src/api/images/index.js
@@ -94,16 +94,8 @@ export const getImageSetViewVersions = ({
   );
 };
 
-export const getImageSetView = ({
-  id,
-  q = {
-    limit: 20,
-    offset: 0,
-    sort_by: '-created_at',
-  },
-}) => {
-  const query = getTableParams(q);
-  return instance.get(`${EDGE_API}/image-sets/view/${id}?${query}`);
+export const getImageSetView = ({ id }) => {
+  return instance.get(`${EDGE_API}/image-sets/view/${id}`);
 };
 
 export const getImagePackageMetadata = (id) => {


### PR DESCRIPTION
# Description

This PR removes query params from `getImageSetView`. No params are used for this API anywhere in the frontend code, and the corresponding backend API `/image-sets/view/:id` does not recognize any.

The image set details page should work the same before and after this change.

Fixes # (THEEDGE-2859)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted