### PR TITLE
redirecting to new update page from Actions dropdown

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -82,6 +82,11 @@ export const Routes = () => {
           path={paths['fleet-management-system-detail']}
           component={DeviceDetail}
         />
+        <Route
+          exact
+          path={paths['fleet-management-system-detail-update']}
+          component={UpdateSystem}
+        />
         <Route exact path={paths['inventory']} component={Inventory} />
         <Route
           exact

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -164,12 +164,7 @@ const DeviceDetail = () => {
                 imageData?.UpdateTransactions?.[0]?.Status === 'BUILDING' ||
                 imageData?.UpdateTransactions?.[0]?.Status === 'CREATED' ||
                 !imageData?.ImageInfo?.UpdatesAvailable?.length > 0,
-              // ||                !updateModal.imageSetId,
               onClick: () => {
-                // setUpdateModal((prevState) => ({
-                //   ...prevState,
-                //   isOpen: true,
-                // }));
                 history.push({
                   pathname: groupName
                     ? `${paths['fleet-management']}/${groupId}/systems/${deviceId}/update`

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -163,13 +163,18 @@ const DeviceDetail = () => {
               isDisabled:
                 imageData?.UpdateTransactions?.[0]?.Status === 'BUILDING' ||
                 imageData?.UpdateTransactions?.[0]?.Status === 'CREATED' ||
-                !imageData?.ImageInfo?.UpdatesAvailable?.length > 0 ||
-                !updateModal.imageSetId,
+                !imageData?.ImageInfo?.UpdatesAvailable?.length > 0,
+              // ||                !updateModal.imageSetId,
               onClick: () => {
-                setUpdateModal((prevState) => ({
-                  ...prevState,
-                  isOpen: true,
-                }));
+                // setUpdateModal((prevState) => ({
+                //   ...prevState,
+                //   isOpen: true,
+                // }));
+                history.push({
+                  pathname: groupName
+                    ? `${paths['fleet-management']}/${groupId}/systems/${deviceId}/update`
+                    : `${paths['inventory']}/${deviceId}/update`,
+                });
               },
             },
           ]}

--- a/src/Routes/Devices/UpdateSystem.js
+++ b/src/Routes/Devices/UpdateSystem.js
@@ -159,11 +159,15 @@ UpdateSystemMain.propTypes = {
 };
 
 const UpdateSystem = () => {
-  const { deviceId } = useParams();
+  const { deviceId, groupId } = useParams();
   const [{ data, isLoading }] = useApi({
     api: () => getDevice(deviceId),
   });
   const device = data?.Device;
+  const groupName = groupId
+    ? device?.DevicesGroups?.find((group) => group.ID.toString() === groupId)
+        ?.Name
+    : null;
 
   return isLoading ? (
     <Backdrop>
@@ -174,12 +178,38 @@ const UpdateSystem = () => {
   ) : (
     <>
       <PageHeader className="pf-m-light">
-        <Breadcrumb>
-          <BreadcrumbItem>
-            <Link to={paths['inventory']}>Systems</Link>
-          </BreadcrumbItem>
-          <BreadcrumbItem>Update</BreadcrumbItem>
-        </Breadcrumb>
+        {!groupName ? (
+          <Breadcrumb ouiaId="systems-list">
+            <BreadcrumbItem>
+              <Link to={paths['inventory']}>Systems</Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
+              <Link to={`${paths['inventory']}/${deviceId}/`}>
+                {device?.DeviceName}
+              </Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem>Update</BreadcrumbItem>
+          </Breadcrumb>
+        ) : (
+          <Breadcrumb ouiaId="groups-list">
+            <BreadcrumbItem>
+              <Link to={`${paths['fleet-management']}`}>Groups</Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
+              <Link to={`${paths['fleet-management']}/${groupId}`}>
+                {groupName}
+              </Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
+              <Link
+                to={`${paths['fleet-management']}/${groupId}/systems/${deviceId}/`}
+              >
+                {device?.DeviceName}
+              </Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem>Update</BreadcrumbItem>
+          </Breadcrumb>
+        )}
         <PageHeaderTitle title="Update" />
         <TextContent className="pf-u-mt-md">
           <Text>

--- a/src/Routes/Devices/UpdateSystem.js
+++ b/src/Routes/Devices/UpdateSystem.js
@@ -216,7 +216,7 @@ const UpdateSystem = () => {
             {'Update '}
             <strong>{device?.DeviceName}</strong>
             {' to a newer version of '}
-            <strong>{device?.ImageName}</strong>
+            <strong>{data?.ImageInfo?.Image?.Name}</strong>
             {' by selecting a new version from the table below.'}
           </Text>
         </TextContent>

--- a/src/components/general-table/ToolbarFooter.js
+++ b/src/components/general-table/ToolbarFooter.js
@@ -17,7 +17,7 @@ const ToolbarFooter = ({
   setPage,
   isFixed,
 }) => {
-  let styles = { padding: '0' };
+  let styles = { padding: '20px' };
   if (isFixed) {
     styles = { ...styles, paddingBottom: '30px', paddingTop: '20px' };
   }

--- a/src/components/general-table/__snapshots__/ToolbarFooter.test.js.snap
+++ b/src/components/general-table/__snapshots__/ToolbarFooter.test.js.snap
@@ -7,7 +7,7 @@ exports[`Repository Footer should render correctly 1`] = `
   data-ouia-component-type="PF4/Toolbar"
   data-ouia-safe="true"
   id="toolbar-footer"
-  style="padding: 0px;"
+  style="padding: 20px;"
 >
   <div
     class="pf-c-toolbar__content"

--- a/src/constants/routeMapper.js
+++ b/src/constants/routeMapper.js
@@ -7,6 +7,8 @@ export const routes = {
   'fleet-management-detail': '/fleet-management/:groupId',
   'fleet-management-system-detail':
     '/fleet-management/:groupId/systems/:deviceId',
+  'fleet-management-system-detail-update':
+    '/fleet-management/:groupId/systems/:deviceId/update',
   inventory: '/inventory',
   'inventory-detail': '/inventory/:deviceId',
   'inventory-detail-update': '/inventory/:deviceId/update',


### PR DESCRIPTION
# Description

Currently, if clicking Update from Actions dropdown in system details, update modal is opened. This PR is fixing that instead of opening the modal the new update page will be shown.

Changes:
New route `/fleet-management/:groupId/systems/:deviceId/update` is added to shown the breadcrumbs correctly.
Also, Toolbar Footer padding is increase to 20px to fix HEEDGE-2851.


Fixes # (issue)
[THEEDGE-2851](https://issues.redhat.com/browse/THEEDGE-2851) and [THEEDGE-2900](https://issues.redhat.com/browse/THEEDGE-2900)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted