### PR TITLE
THEEDGE-2929

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,8 +14,6 @@ const App = (props) => {
   const history = useHistory();
   const [isAuth, setIsAuth] = useState(null);
   useEffect(() => {
-    insights.chrome.init();
-    // TODO change this to your appname
     insights.chrome.identifyApp('fleet-management');
 
     insights.chrome.on('APP_NAVIGATION', (event) =>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -67,49 +67,46 @@ export const Routes = () => {
     >
       <Switch>
         <Route exact path={paths.groups} component={Groups} />
-        <Route exact path={paths['groups-detail']} component={GroupsDetail} />
+        <Route exact path={paths.groupsDetail} component={GroupsDetail} />
 
-        {/* <Route path={paths['device-detail']} component={DeviceDetail} /> */}
+        {/* <Route path={paths.deviceDetail} component={DeviceDetail} /> */}
         {/* <Route path={paths.canaries} component={Canaries} /> */}
-        <Route exact path={paths['fleet-management']} component={Groups} />
+        <Route exact path={paths.fleetManagement} component={Groups} />
         <Route
           exact
-          path={paths['fleet-management-detail']}
+          path={paths.fleetManagementDetail}
           component={GroupsDetail}
         />
         <Route
           exact
-          path={paths['fleet-management-system-detail']}
+          path={paths.fleetManagementSystemDetail}
           component={DeviceDetail}
         />
         <Route
           exact
-          path={paths['fleet-management-system-detail-update']}
+          path={paths.fleetManagementSystemDetailUpdate}
           component={UpdateSystem}
         />
-        <Route exact path={paths['inventory']} component={Inventory} />
+        <Route exact path={paths.inventory} component={Inventory} />
         <Route
           exact
-          path={paths['inventory-detail-update']}
+          path={paths.inventoryDetailUpdate}
           component={UpdateSystem}
         />
-        <Route path={paths['inventory-detail']} component={DeviceDetail} />
-        <Route
-          path={paths['manage-images-detail-version']}
-          component={ImageDetail}
-        />
-        <Route path={paths['manage-images-detail']} component={ImageDetail} />
-        <Route path={paths['manage-images']} component={Images} />
+        <Route path={paths.inventoryDetail} component={DeviceDetail} />
+        <Route path={paths.manageImagesDetailVersion} component={ImageDetail} />
+        <Route path={paths.manageImagesDetail} component={ImageDetail} />
+        <Route path={paths.manageImages} component={Images} />
 
-        <Route exact path={paths['repositories']} component={Repositories} />
+        <Route exact path={paths.repositories} component={Repositories} />
 
         <Route
           exact
-          path={paths['learning-resources']}
+          path={paths.learningResources}
           component={LearningResources}
         />
         <Route>
-          <Redirect to={paths['fleet-management']} />
+          <Redirect to={paths.fleetManagement} />
         </Route>
       </Switch>
     </Suspense>

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -16,7 +16,7 @@ import {
   InventoryDetailHead,
   DetailWrapper,
 } from '@redhat-cloud-services/frontend-components/Inventory';
-import { useParams, useHistory, Link } from 'react-router-dom';
+import { useParams, useHistory, useLocation, Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { deviceDetail } from '../../store/deviceDetail';
 import { RegistryContext } from '../../store';
@@ -45,6 +45,7 @@ const DeviceDetail = () => {
   );
 
   const history = useHistory();
+  const { pathname } = useLocation();
   const { deviceId, groupId } = useParams();
   const [imageId, setImageId] = useState(null);
   const { getRegistry } = useContext(RegistryContext);
@@ -165,11 +166,11 @@ const DeviceDetail = () => {
                 imageData?.UpdateTransactions?.[0]?.Status === 'CREATED' ||
                 !imageData?.ImageInfo?.UpdatesAvailable?.length > 0,
               onClick: () => {
-                history.state = { prevState: history.location.pathname };
                 history.push({
                   pathname: groupName
                     ? `${paths['fleet-management']}/${groupId}/systems/${deviceId}/update`
                     : `${paths['inventory']}/${deviceId}/update`,
+                  state: { prevState: pathname },
                 });
               },
             },
@@ -229,7 +230,7 @@ const DeviceDetail = () => {
         >
           <UpdateDeviceModal
             navigateBack={() => {
-              history.push({ pathname: history.location.pathname });
+              history.push({ pathname });
               setUpdateModal((prevState) => {
                 return {
                   ...prevState,

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -165,6 +165,7 @@ const DeviceDetail = () => {
                 imageData?.UpdateTransactions?.[0]?.Status === 'CREATED' ||
                 !imageData?.ImageInfo?.UpdatesAvailable?.length > 0,
               onClick: () => {
+                history.state = { prevState: history.location.pathname };
                 history.push({
                   pathname: groupName
                     ? `${paths['fleet-management']}/${groupId}/systems/${deviceId}/update`

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -16,7 +16,7 @@ import {
   InventoryDetailHead,
   DetailWrapper,
 } from '@redhat-cloud-services/frontend-components/Inventory';
-import { useParams, useHistory, useLocation, Link } from 'react-router-dom';
+import { useHistory, useLocation, useParams, Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { deviceDetail } from '../../store/deviceDetail';
 import { RegistryContext } from '../../store';
@@ -43,7 +43,6 @@ const DeviceDetail = () => {
     },
     {}
   );
-
   const history = useHistory();
   const { pathname } = useLocation();
   const { deviceId, groupId } = useParams();
@@ -131,7 +130,7 @@ const DeviceDetail = () => {
         {!groupName ? (
           <Breadcrumb ouiaId="systems-list">
             <BreadcrumbItem>
-              <Link to={paths['inventory']}>Systems</Link>
+              <Link to={paths.inventory}>Systems</Link>
             </BreadcrumbItem>
             <BreadcrumbItem isActive>
               <div className="ins-c-inventory__detail--breadcrumb-name">
@@ -142,10 +141,10 @@ const DeviceDetail = () => {
         ) : (
           <Breadcrumb ouiaId="groups-list">
             <BreadcrumbItem>
-              <Link to={`${paths['fleet-management']}`}>Groups</Link>
+              <Link to={paths.fleetManagement}>Groups</Link>
             </BreadcrumbItem>
             <BreadcrumbItem>
-              <Link to={`${paths['fleet-management']}/${groupId}`}>
+              <Link to={`${paths.fleetManagement}/${groupId}`}>
                 {groupName}
               </Link>
             </BreadcrumbItem>
@@ -168,9 +167,9 @@ const DeviceDetail = () => {
               onClick: () => {
                 history.push({
                   pathname: groupName
-                    ? `${paths['fleet-management']}/${groupId}/systems/${deviceId}/update`
-                    : `${paths['inventory']}/${deviceId}/update`,
-                  state: { prevState: pathname },
+                    ? `${paths.fleetManagement}/${groupId}/systems/${deviceId}/update`
+                    : `${paths.inventory}/${deviceId}/update`,
+                  search: '?from_details=true',
                 });
               },
             },

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -166,9 +166,7 @@ const DeviceDetail = () => {
                 !imageData?.ImageInfo?.UpdatesAvailable?.length > 0,
               onClick: () => {
                 history.push({
-                  pathname: groupName
-                    ? `${paths.fleetManagement}/${groupId}/systems/${deviceId}/update`
-                    : `${paths.inventory}/${deviceId}/update`,
+                  pathname: `${pathname}/update`,
                   search: '?from_details=true',
                 });
               },

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -217,6 +217,7 @@ const DeviceTable = ({
   fetchDevices,
   isSystemsView = false,
   isAddSystemsView = false,
+  groupId,
 }) => {
   const canBeRemoved = setRemoveModal;
   const canBeAdded = setIsAddModalOpen;
@@ -272,8 +273,11 @@ const DeviceTable = ({
       actions.push({
         title: 'Update',
         onClick: (_event, _rowId, rowData) => {
+          history.state = { prevState: history.location.pathname };
           history.push({
-            pathname: `${paths['inventory']}/${rowData.rowInfo.id}/update`,
+            pathname: groupId
+              ? `${paths['fleet-management']}/${groupId}/systems/${rowData.rowInfo.id}/update`
+              : `${paths['inventory']}/${rowData.rowInfo.id}/update`,
           });
         },
       });
@@ -399,6 +403,7 @@ DeviceTable.propTypes = {
   fetchDevices: PropTypes.func,
   isSystemsView: PropTypes.bool,
   isAddSystemsView: PropTypes.bool,
+  groupId: PropTypes.number,
 };
 
 export default DeviceTable;

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -144,7 +144,7 @@ const createRows = (devices, hasLinks, fetchDevices, deviceLinkBase) => {
         {
           title: ImageName ? (
             hasLinks ? (
-              <Link to={`${paths['manage-images']}/${ImageSetID}/`}>
+              <Link to={`${paths.manageImages}/${ImageSetID}`}>
                 {ImageName}
               </Link>
             ) : (
@@ -217,7 +217,6 @@ const DeviceTable = ({
   fetchDevices,
   isSystemsView = false,
   isAddSystemsView = false,
-  groupId,
 }) => {
   const canBeRemoved = setRemoveModal;
   const canBeAdded = setIsAddModalOpen;
@@ -226,10 +225,8 @@ const DeviceTable = ({
   const { pathname, search } = useLocation();
 
   // Create base URL path for system detail link
-  let deviceBaseUrl = pathname;
-  if (deviceBaseUrl !== paths.inventory) {
-    deviceBaseUrl = deviceBaseUrl + '/systems';
-  }
+  const deviceBaseUrl =
+    pathname === paths.inventory ? pathname : `${pathname}/systems`;
 
   const actionResolver = (rowData) => {
     const actions = [];
@@ -275,10 +272,7 @@ const DeviceTable = ({
         title: 'Update',
         onClick: (_event, _rowId, rowData) => {
           history.push({
-            pathname: groupId
-              ? `${paths['fleet-management']}/${groupId}/systems/${rowData.rowInfo.id}/update`
-              : `${paths['inventory']}/${rowData.rowInfo.id}/update`,
-            state: { prevState: pathname },
+            pathname: `${deviceBaseUrl}/${rowData.rowInfo.id}/update`,
           });
         },
       });
@@ -404,7 +398,6 @@ DeviceTable.propTypes = {
   fetchDevices: PropTypes.func,
   isSystemsView: PropTypes.bool,
   isAddSystemsView: PropTypes.bool,
-  groupId: PropTypes.number,
 };
 
 export default DeviceTable;

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -2,12 +2,12 @@ import React from 'react';
 import GeneralTable from '../../components/general-table/GeneralTable';
 import PropTypes from 'prop-types';
 import { routes as paths } from '../../constants/routeMapper';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { cellWidth } from '@patternfly/react-table';
 import { Tooltip } from '@patternfly/react-core';
 import CustomEmptyState from '../../components/Empty';
-import { emptyStateNoFliters } from '../../utils';
+import { emptyStateNoFilters } from '../../utils';
 import DeviceStatus, { getDeviceStatus } from '../../components/Status';
 import RetryUpdatePopover from './RetryUpdatePopover';
 
@@ -223,9 +223,10 @@ const DeviceTable = ({
   const canBeAdded = setIsAddModalOpen;
   const canBeUpdated = isSystemsView;
   const history = useHistory();
+  const { pathname, search } = useLocation();
 
   // Create base URL path for system detail link
-  let deviceBaseUrl = history.location.pathname;
+  let deviceBaseUrl = pathname;
   if (deviceBaseUrl !== paths.inventory) {
     deviceBaseUrl = deviceBaseUrl + '/systems';
   }
@@ -273,11 +274,11 @@ const DeviceTable = ({
       actions.push({
         title: 'Update',
         onClick: (_event, _rowId, rowData) => {
-          history.state = { prevState: history.location.pathname };
           history.push({
             pathname: groupId
               ? `${paths['fleet-management']}/${groupId}/systems/${rowData.rowInfo.id}/update`
               : `${paths['inventory']}/${rowData.rowInfo.id}/update`,
+            state: { prevState: pathname },
           });
         },
       });
@@ -305,7 +306,7 @@ const DeviceTable = ({
 
   return (
     <>
-      {isSystemsView && emptyStateNoFliters(isLoading, count, history) ? (
+      {isSystemsView && emptyStateNoFilters(isLoading, count, search) ? (
         <CustomEmptyState
           data-testid="general-table-empty-state-no-data"
           icon={'plus'}

--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -10,7 +10,7 @@ import RemoveDeviceModal from './RemoveDeviceModal';
 import CreateGroupModal from '../Groups/CreateGroupModal';
 import useApi from '../../hooks/useApi';
 import { getInventory } from '../../api/devices';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
 const UpdateDeviceModal = React.lazy(() =>
@@ -19,6 +19,7 @@ const UpdateDeviceModal = React.lazy(() =>
 
 const Inventory = () => {
   const history = useHistory();
+  const { pathname } = useLocation();
   const [response, fetchDevices] = useApi({
     api: getInventory,
     tableReload: true,
@@ -141,7 +142,7 @@ const Inventory = () => {
         >
           <UpdateDeviceModal
             navigateBack={() => {
-              history.push({ pathname: history.location.pathname });
+              history.push({ pathname });
               setUpdateModal((prevState) => {
                 return {
                   ...prevState,

--- a/src/Routes/Devices/UpdateSystem.js
+++ b/src/Routes/Devices/UpdateSystem.js
@@ -33,8 +33,7 @@ import {
   Tbody,
   Td,
 } from '@patternfly/react-table';
-import { useParams } from 'react-router';
-import { Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 
 const CurrentVersion = ({ image }) => {
   const current_version = [

--- a/src/Routes/Devices/UpdateSystem.js
+++ b/src/Routes/Devices/UpdateSystem.js
@@ -180,10 +180,10 @@ const UpdateSystem = () => {
         {!groupName ? (
           <Breadcrumb ouiaId="systems-list">
             <BreadcrumbItem>
-              <Link to={paths['inventory']}>Systems</Link>
+              <Link to={paths.inventory}>Systems</Link>
             </BreadcrumbItem>
             <BreadcrumbItem>
-              <Link to={`${paths['inventory']}/${deviceId}/`}>
+              <Link to={`${paths.inventory}/${deviceId}/`}>
                 {device?.DeviceName}
               </Link>
             </BreadcrumbItem>
@@ -192,16 +192,16 @@ const UpdateSystem = () => {
         ) : (
           <Breadcrumb ouiaId="groups-list">
             <BreadcrumbItem>
-              <Link to={`${paths['fleet-management']}`}>Groups</Link>
+              <Link to={paths.fleetManagement}>Groups</Link>
             </BreadcrumbItem>
             <BreadcrumbItem>
-              <Link to={`${paths['fleet-management']}/${groupId}`}>
+              <Link to={`${paths.fleetManagement}/${groupId}`}>
                 {groupName}
               </Link>
             </BreadcrumbItem>
             <BreadcrumbItem>
               <Link
-                to={`${paths['fleet-management']}/${groupId}/systems/${deviceId}/`}
+                to={`${paths.fleetManagement}/${groupId}/systems/${deviceId}/`}
               >
                 {device?.DeviceName}
               </Link>

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import GeneralTable from '../../components/general-table/GeneralTable';
 import { headerCol } from '@patternfly/react-table';
 import { Button, Divider } from '@patternfly/react-core';
@@ -92,14 +92,8 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
     handleClose();
   };
 
-  useEffect(() => {
-    if (history.action === 'POP') {
-      history.goBack();
-    }
-  }, [history.action]);
-
   const handleClose = () => {
-    history.goBack();
+    history.go(-2);
   };
 
   return (

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -33,6 +33,7 @@ const columns = [
 const UpdateVersionTable = ({ data, isLoading, hasError }) => {
   const [selectedVersion, setSelectedVersion] = useState(null);
   const [selectedCommitID, setSelectedCommitID] = useState(null);
+  const [isUpdateSubmitted, setIsUpdateSubmitted] = useState(false);
   const dispatch = useDispatch();
   const history = useHistory();
   const { pathname, search } = useLocation();
@@ -71,7 +72,8 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
     setSelectedCommitID(value);
   };
 
-  const handleUpdateEvent = () => {
+  const handleUpdateEvent = async () => {
+    setIsUpdateSubmitted(true);
     const statusMessages = {
       onInfo: {
         title: 'Updating system',
@@ -83,7 +85,7 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
       },
     };
 
-    apiWithToast(
+    await apiWithToast(
       dispatch,
       () =>
         updateSystem({
@@ -94,6 +96,7 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
     );
 
     handleClose();
+    setIsUpdateSubmitted(false);
   };
 
   const handleClose = () => {
@@ -158,7 +161,7 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
           style={{ left: '60px' }}
           key="confirm"
           variant="primary"
-          isDisabled={!selectedVersion}
+          isDisabled={!selectedVersion || isUpdateSubmitted}
           onClick={() => handleUpdateEvent()}
         >
           Update system

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -4,7 +4,7 @@ import { headerCol } from '@patternfly/react-table';
 import { Button, Divider } from '@patternfly/react-core';
 import { updateSystem } from '../../api/devices';
 import { useDispatch } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory, useLocation } from 'react-router-dom';
 import apiWithToast from '../../utils/apiWithToast';
 import PropTypes from 'prop-types';
 import { routes as paths } from '../../constants/routeMapper';
@@ -35,6 +35,7 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
   const [selectedCommitID, setSelectedCommitID] = useState(null);
   const dispatch = useDispatch();
   const history = useHistory();
+  const { pathname } = useLocation();
 
   const buildRows = data?.map((rowData) => {
     const {
@@ -96,9 +97,7 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
 
   const handleClose = () => {
     history.push({
-      pathname: history.state?.prevState
-        ? history.state?.prevState
-        : paths[history.location.pathname.split('/')[1]],
+      pathname: history.state?.prevState || paths[pathname.split('/')[1]],
     });
   };
 

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -7,6 +7,7 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import apiWithToast from '../../utils/apiWithToast';
 import PropTypes from 'prop-types';
+import { routes as paths } from '../../constants/routeMapper';
 
 const filters = [
   { label: 'Version', type: 'text' },
@@ -95,7 +96,9 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
 
   const handleClose = () => {
     history.push({
-      pathname: history.state.prevState,
+      pathname: history.state?.prevState
+        ? history.state?.prevState
+        : paths[history.location.pathname.split('/')[1]],
     });
   };
 

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import GeneralTable from '../../components/general-table/GeneralTable';
 import { headerCol } from '@patternfly/react-table';
 import { Button, Divider } from '@patternfly/react-core';
@@ -7,7 +7,6 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import apiWithToast from '../../utils/apiWithToast';
 import PropTypes from 'prop-types';
-import { routes as paths } from '../../constants/routeMapper';
 
 const filters = [
   { label: 'Version', type: 'text' },
@@ -93,8 +92,14 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
     handleClose();
   };
 
+  useEffect(() => {
+    if (history.action === 'POP') {
+      history.goBack();
+    }
+  }, [history.action]);
+
   const handleClose = () => {
-    history.push(paths['inventory']);
+    history.goBack();
   };
 
   return (

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -4,7 +4,7 @@ import { headerCol } from '@patternfly/react-table';
 import { Button, Divider } from '@patternfly/react-core';
 import { updateSystem } from '../../api/devices';
 import { useDispatch } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import apiWithToast from '../../utils/apiWithToast';
 import PropTypes from 'prop-types';
 import { routes as paths } from '../../constants/routeMapper';
@@ -35,7 +35,8 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
   const [selectedCommitID, setSelectedCommitID] = useState(null);
   const dispatch = useDispatch();
   const history = useHistory();
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
+  const match = useRouteMatch();
 
   const buildRows = data?.map((rowData) => {
     const {
@@ -96,9 +97,25 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
   };
 
   const handleClose = () => {
-    history.push({
-      pathname: history.state?.prevState || paths[pathname.split('/')[1]],
-    });
+    // Return either to the system detail, group detail, or inventory page,
+    // depending on path and from_details param
+    let destPath = paths.inventory;
+    if (match.path === paths.inventoryDetailUpdate) {
+      destPath = search.includes('from_details=true')
+        ? paths.inventoryDetail
+        : paths.inventory;
+    }
+    if (match.path === paths.fleetManagementSystemDetailUpdate) {
+      destPath = search.includes('from_details=true')
+        ? paths.fleetManagementSystemDetail
+        : paths.fleetManagementDetail;
+    }
+
+    // Construct destination path
+    const pathLen = destPath.split('/').length;
+    const dest = pathname.split('/').slice(0, pathLen).join('/');
+
+    history.push({ pathname: dest });
   };
 
   return (

--- a/src/Routes/Devices/UpdateVersionTable.js
+++ b/src/Routes/Devices/UpdateVersionTable.js
@@ -89,11 +89,14 @@ const UpdateVersionTable = ({ data, isLoading, hasError }) => {
         }),
       statusMessages
     );
+
     handleClose();
   };
 
   const handleClose = () => {
-    history.go(-2);
+    history.push({
+      pathname: history.state.prevState,
+    });
   };
 
   return (

--- a/src/Routes/Groups/GroupTable.js
+++ b/src/Routes/Groups/GroupTable.js
@@ -1,7 +1,7 @@
 import React, { useState, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import GeneralTable from '../../components/general-table/GeneralTable';
-import { Link } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { routes as paths } from '../../constants/routeMapper';
 import { Bullseye, Spinner, Tooltip } from '@patternfly/react-core';
 
@@ -40,6 +40,9 @@ const GroupTable = ({
   setHasModalSubmitted,
   fetchGroups,
 }) => {
+  const history = useHistory();
+  const { pathname } = useLocation();
+
   const [updateModal, setUpdateModal] = useState({
     isOpen: false,
     deviceData: null,
@@ -179,7 +182,7 @@ const GroupTable = ({
         >
           <UpdateDeviceModal
             navigateBack={() => {
-              history.push({ pathname: history.location.pathname });
+              history.push({ pathname });
               setUpdateModal((prevState) => {
                 return {
                   ...prevState,

--- a/src/Routes/Groups/GroupTable.js
+++ b/src/Routes/Groups/GroupTable.js
@@ -124,7 +124,7 @@ const GroupTable = ({
       },
       cells: [
         {
-          title: <Link to={`${paths['fleet-management']}/${ID}`}>{Name}</Link>,
+          title: <Link to={`${paths.fleetManagement}/${ID}`}>{Name}</Link>,
         },
         {
           title: systems.length,

--- a/src/Routes/Groups/Groups.js
+++ b/src/Routes/Groups/Groups.js
@@ -12,11 +12,11 @@ import CreateGroupModal from './CreateGroupModal';
 import RenameGroupModal from './RenameGroupModal';
 import DeleteGroupModal from './DeleteGroupModal';
 import useApi from '../../hooks/useApi';
-import { useHistory } from 'react-router-dom';
-import { emptyStateNoFliters } from '../../utils';
+import { useLocation } from 'react-router-dom';
+import { emptyStateNoFilters } from '../../utils';
 
 const Groups = () => {
-  const history = useHistory();
+  const { search } = useLocation();
   const [response, fetchGroups] = useApi({
     api: getGroups,
     tableReload: true,
@@ -50,7 +50,7 @@ const Groups = () => {
         <PageHeaderTitle title="Groups" />
       </PageHeader>
       <Main className="edge-devices">
-        {!emptyStateNoFliters(isLoading, data?.count, history) ? (
+        {!emptyStateNoFilters(isLoading, data?.count, search) ? (
           <GroupTable
             data={data?.data || []}
             count={data?.count}

--- a/src/Routes/Groups/__snapshots__/Groups.test.js.snap
+++ b/src/Routes/Groups/__snapshots__/Groups.test.js.snap
@@ -94,7 +94,7 @@ exports[`Groups should render correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-0"
+      id="toolbar-header-expandable-content-3"
     >
       <div
         class="pf-c-toolbar__group"
@@ -113,7 +113,7 @@ exports[`Groups should render correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-1"
+      id="toolbar-header-expandable-content-4"
     >
       <div
         class="pf-c-toolbar__group"

--- a/src/Routes/GroupsDetail/GroupsDetail.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Suspense } from 'react';
+import React, { useState, Suspense } from 'react';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -17,7 +17,7 @@ import {
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import Empty from '../../components/Empty';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { routes as paths } from '../../constants/routeMapper';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 import DeviceTable from '../Devices/DeviceTable';
@@ -28,11 +28,7 @@ import {
   removeDevicesFromGroup,
 } from '../../api/groups';
 import AddSystemsToGroupModal from '../Devices/AddSystemsToGroupModal';
-import {
-  canUpdateSelectedDevices,
-  emptyStateNoFliters,
-  stateToUrlSearch,
-} from '../../utils';
+import { canUpdateSelectedDevices, emptyStateNoFilters } from '../../utils';
 import useApi from '../../hooks/useApi';
 import apiWithToast from '../../utils/apiWithToast';
 import { useDispatch } from 'react-redux';
@@ -52,6 +48,8 @@ const GroupsDetail = () => {
   const dispatch = useDispatch();
   const params = useParams();
   const history = useHistory();
+  const { search, pathname } = useLocation();
+
   const { groupId } = params;
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -95,13 +93,6 @@ const GroupsDetail = () => {
         ? `${deviceIds.length} system${deviceIds.length === 1 ? '' : 's'}`
         : `${removeModal.name}`
     } from ${groupName}?`;
-
-  useEffect(() => {
-    history.push({
-      pathname: history.location.pathname,
-      search: stateToUrlSearch('add_system_modal=true', isAddModalOpen),
-    });
-  }, [isAddModalOpen]);
 
   const handleSingleDeviceRemoval = () => {
     const statusMessages = {
@@ -235,10 +226,10 @@ const GroupsDetail = () => {
         </Flex>
       </PageHeader>
       <Main className="edge-devices">
-        {!emptyStateNoFliters(
+        {!emptyStateNoFilters(
           isLoading,
           data?.DeviceGroup?.Devices.length,
-          history
+          search
         ) ? (
           <DeviceTable
             data={data?.DevicesView?.devices || []}
@@ -281,7 +272,7 @@ const GroupsDetail = () => {
             setHasModalSubmitted={setHasModalSubmitted}
             fetchDevices={fetchDevices}
             isAddSystemsView={true}
-            groupId={groupId}
+            groupId={parseInt(groupId)}
           />
         ) : (
           <Flex justifyContent={{ default: 'justifyContentCenter' }}>
@@ -348,7 +339,7 @@ const GroupsDetail = () => {
         >
           <UpdateDeviceModal
             navigateBack={() => {
-              history.push({ pathname: history.location.pathname });
+              history.push({ pathname });
               setUpdateModal((prevState) => {
                 return {
                   ...prevState,

--- a/src/Routes/GroupsDetail/GroupsDetail.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.js
@@ -281,6 +281,7 @@ const GroupsDetail = () => {
             setHasModalSubmitted={setHasModalSubmitted}
             fetchDevices={fetchDevices}
             isAddSystemsView={true}
+            groupId={groupId}
           />
         ) : (
           <Flex justifyContent={{ default: 'justifyContentCenter' }}>

--- a/src/Routes/GroupsDetail/GroupsDetail.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.js
@@ -139,7 +139,7 @@ const GroupsDetail = () => {
         {groupName ? (
           <Breadcrumb>
             <BreadcrumbItem>
-              <Link to={`${paths['fleet-management']}`}>Groups</Link>
+              <Link to={paths.fleetManagement}>Groups</Link>
             </BreadcrumbItem>
             <BreadcrumbItem>{groupName}</BreadcrumbItem>
           </Breadcrumb>
@@ -272,7 +272,6 @@ const GroupsDetail = () => {
             setHasModalSubmitted={setHasModalSubmitted}
             fetchDevices={fetchDevices}
             isAddSystemsView={true}
-            groupId={parseInt(groupId)}
           />
         ) : (
           <Flex justifyContent={{ default: 'justifyContentCenter' }}>
@@ -357,7 +356,7 @@ const GroupsDetail = () => {
         <DeleteGroupModal
           isModalOpen={isDeleteModalOpen}
           setIsModalOpen={setIsDeleteModalOpen}
-          reloadData={() => history.push(paths['fleet-management'])}
+          reloadData={() => history.push(paths.fleetManagement)}
           modalState={modalState}
         />
       )}

--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -81,7 +81,7 @@ const createRows = (data) => {
     cells: [
       {
         title: (
-          <Link to={`${paths['manage-images']}/${image_set?.ID}`}>
+          <Link to={`${paths.manageImages}/${image_set?.ID}`}>
             {image_set?.Name}
           </Link>
         ),

--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -7,8 +7,8 @@ import { Text, Tooltip } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { cellWidth } from '@patternfly/react-table';
 import CustomEmptyState from '../../components/Empty';
-import { useHistory } from 'react-router-dom';
-import { emptyStateNoFliters } from '../../utils';
+import { useLocation } from 'react-router-dom';
+import { emptyStateNoFilters } from '../../utils';
 import Status from '../../components/Status';
 
 const TooltipSelectorRef = ({ index }) => (
@@ -118,7 +118,7 @@ const ImageTable = ({
   hasModalSubmitted,
   setHasModalSubmitted,
 }) => {
-  const history = useHistory();
+  const { search } = useLocation();
 
   const actionResolver = (rowData) => {
     const actionsArray = [];
@@ -164,7 +164,7 @@ const ImageTable = ({
 
   return (
     <>
-      {emptyStateNoFliters(isLoading, count, history) ? (
+      {emptyStateNoFilters(isLoading, count, search) ? (
         <CustomEmptyState
           data-testid="general-table-empty-state-no-data"
           icon={'plus'}

--- a/src/Routes/ImageManager/ImageTable.js
+++ b/src/Routes/ImageManager/ImageTable.js
@@ -56,7 +56,7 @@ const createRows = (data) => {
     cells: [
       {
         title: (
-          <Link to={`${paths['manage-images-detail']}/${image.ID}`}>
+          <Link to={`${paths.manageImagesDetail}/${image.ID}`}>
             {image.Name}
           </Link>
         ),

--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -5,7 +5,7 @@ import {
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { Spinner, Bullseye } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import ImageSetsTable from './ImageSetsTable';
 import { stateToUrlSearch } from '../../utils';
 import { getImageSets } from '../../api/images';
@@ -25,6 +25,7 @@ const UpdateImageWizard = React.lazy(() =>
 
 const Images = () => {
   const history = useHistory();
+  const { pathname, search } = useLocation();
 
   const [response, fetchImageSets] = useApi({
     api: getImageSets,
@@ -41,16 +42,16 @@ const Images = () => {
 
   const openCreateWizard = () => {
     history.push({
-      pathname: history.location.pathname,
-      search: stateToUrlSearch('create_image=true', true),
+      pathname,
+      search: stateToUrlSearch('create_image=true', true, search),
     });
     setIsCreateWizardOpen(true);
   };
 
   const openUpdateWizard = (id) => {
     history.push({
-      pathname: history.location.pathname,
-      search: stateToUrlSearch('update_image=true', true),
+      pathname,
+      search: stateToUrlSearch('update_image=true', true, search),
     });
     setUpdateWizard({
       isOpen: true,
@@ -92,8 +93,8 @@ const Images = () => {
           <CreateImageWizard
             navigateBack={() => {
               history.push({
-                pathname: history.location.pathname,
-                search: stateToUrlSearch('create_image=true', false),
+                pathname,
+                search: stateToUrlSearch('create_image=true', false, search),
               });
               setIsCreateWizardOpen(false);
             }}
@@ -112,8 +113,8 @@ const Images = () => {
           <UpdateImageWizard
             navigateBack={() => {
               history.push({
-                pathname: history.location.pathname,
-                search: stateToUrlSearch('update_image=true', false),
+                pathname,
+                search: stateToUrlSearch('update_image=true', false, search),
               });
               setUpdateWizard((prevState) => {
                 return {

--- a/src/Routes/ImageManagerDetail/DetailsHeader.js
+++ b/src/Routes/ImageManagerDetail/DetailsHeader.js
@@ -72,18 +72,18 @@ const DetailsHead = ({ imageData, imageVersion, openUpdateWizard }) => {
       {!imageData.isLoading && imageData.hasError ? (
         <Breadcrumb>
           <BreadcrumbItem>
-            <Link to={paths['manage-images']}>Back to Manage Images</Link>
+            <Link to={paths.manageImages}>Back to Manage Images</Link>
           </BreadcrumbItem>
         </Breadcrumb>
       ) : (
         <>
           <Breadcrumb>
             <BreadcrumbItem>
-              <Link to={paths['manage-images']}>Manage Images</Link>
+              <Link to={paths.manageImages}>Manage Images</Link>
             </BreadcrumbItem>
             {imageVersion ? (
               <BreadcrumbItem>
-                <Link to={`${paths['manage-images']}/${data?.ImageSet?.ID}`}>
+                <Link to={`${paths.manageImages}/${data?.ImageSet?.ID}`}>
                   {data?.ImageSet?.Name}
                 </Link>
               </BreadcrumbItem>

--- a/src/Routes/ImageManagerDetail/ImageDetail.js
+++ b/src/Routes/ImageManagerDetail/ImageDetail.js
@@ -1,7 +1,7 @@
 import React, { Fragment, Suspense, useEffect, useState } from 'react';
 import { PageHeader } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { Stack, StackItem, Spinner, Bullseye } from '@patternfly/react-core';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useHistory, useLocation } from 'react-router-dom';
 import DetailsHead from './DetailsHeader';
 import ImageDetailTabs from './ImageDetailTabs';
 import UpdateImageWizard from '../ImageManager/UpdateImageWizard';
@@ -11,6 +11,7 @@ import { getImageSetView } from '../../api/images';
 const ImageDetail = () => {
   const { imageId, imageVersionId } = useParams();
   const history = useHistory();
+  const { pathname } = useLocation();
   const [updateWizard, setUpdateWizard] = useState({
     isOpen: false,
     updateId: null,
@@ -27,7 +28,7 @@ const ImageDetail = () => {
 
   const openUpdateWizard = (id) => {
     history.push({
-      pathname: history.location.pathname,
+      pathname,
       search: new URLSearchParams({
         update_image: true,
       }).toString(),
@@ -79,7 +80,7 @@ const ImageDetail = () => {
         >
           <UpdateImageWizard
             navigateBack={() => {
-              history.push({ pathname: history.location.pathname });
+              history.push({ pathname });
               setUpdateWizard((prevState) => ({ ...prevState, isOpen: false }));
             }}
             updateImageID={updateWizard.updateId}

--- a/src/Routes/ImageManagerDetail/ImageDetailTab.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTab.js
@@ -51,7 +51,7 @@ const ImageDetailTab = ({ imageData, imageVersion }) => {
   const renderAdditionalPackageLink = () => {
     return (
       <Link
-        to={`${paths['manage-images']}/${data?.image?.ImageSetID}/versions/${data?.image?.ID}/packages/additional`}
+        to={`${paths.manageImages}/${data?.image?.ImageSetID}/versions/${data?.image?.ID}/packages/additional`}
       >
         {data?.additional_packages}
       </Link>
@@ -61,7 +61,7 @@ const ImageDetailTab = ({ imageData, imageVersion }) => {
   const renderTotalPackageLink = () => {
     return (
       <Link
-        to={`${paths['manage-images']}/${data?.image?.ImageSetID}/versions/${data?.image?.ID}/packages/all`}
+        to={`${paths.manageImages}/${data?.image?.ImageSetID}/versions/${data?.image?.ID}/packages/all`}
       >
         {data?.packages}
       </Link>

--- a/src/Routes/ImageManagerDetail/ImageDetailTabs.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTabs.js
@@ -65,7 +65,7 @@ const ImageDetailTabs = ({
           body="Please check you have the correct link with the correct image Id."
           primaryAction={{
             text: 'Back to Manage Images',
-            href: paths['manage-images'],
+            href: paths.manageImages,
           }}
           secondaryActions={[]}
         />

--- a/src/Routes/ImageManagerDetail/ImageDetailTabs.js
+++ b/src/Routes/ImageManagerDetail/ImageDetailTabs.js
@@ -24,8 +24,8 @@ const ImageDetailTabs = ({
   imageVersion,
   isLoading,
 }) => {
-  const location = useLocation();
   const history = useHistory();
+  const { pathname } = useLocation();
   const [activeTabKey, setActiveTabkey] = useState(tabs.details);
   const activeTab = imageVersion ? 'imageTab' : 'imageSetTab';
 
@@ -37,7 +37,7 @@ const ImageDetailTabs = ({
     'imageTab',
     'packagesToggle',
   ];
-  const imageUrlMapper = mapUrlToObj(location.pathname, keys);
+  const imageUrlMapper = mapUrlToObj(pathname, keys);
 
   const handleTabClick = (_event, tabIndex) => {
     const selectedTab =
@@ -54,7 +54,7 @@ const ImageDetailTabs = ({
     imageUrlMapper['imageTab']
       ? setActiveTabkey(tabs[imageUrlMapper['imageTab']])
       : setActiveTabkey(tabs[imageUrlMapper['imageSetTab']]);
-  }, [location.pathname]);
+  }, [pathname]);
 
   return (
     <>

--- a/src/Routes/ImageManagerDetail/ImagePackagesTab.js
+++ b/src/Routes/ImageManagerDetail/ImagePackagesTab.js
@@ -91,9 +91,10 @@ const tabsToIndex = {
 };
 
 const ImagePackagesTab = ({ imageVersion }) => {
-  const location = useLocation();
   const history = useHistory();
-  const splitUrl = location.pathname.split('/');
+  const { pathname } = useLocation();
+
+  const splitUrl = pathname.split('/');
   const defaultToggle = splitUrl.length === 7 ? tabsToIndex[splitUrl[6]] : 1;
   // Distribution examples would be: rhel-86, rhel-90, and rhel-100
   const distribution = imageVersion?.image?.Distribution?.split('-')[1].slice(

--- a/src/Routes/ImageManagerDetail/ImageVersionDetail.js
+++ b/src/Routes/ImageManagerDetail/ImageVersionDetail.js
@@ -7,7 +7,7 @@ import {
   Spinner,
   Bullseye,
 } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import DetailsHead from './DetailsHeader';
 import ImageDetailTabs from './ImageDetailTabs';
 import PropTypes from 'prop-types';
@@ -20,6 +20,7 @@ const UpdateImageWizard = React.lazy(() =>
 
 const ImageVersionDetail = ({ data, imageVersion }) => {
   const history = useHistory();
+  const { pathname } = useLocation();
   const [isUpdateWizardOpen, setIsUpdateWizardOpen] = useState(false);
   const [imageData, setImageData] = useState({});
 
@@ -29,7 +30,7 @@ const ImageVersionDetail = ({ data, imageVersion }) => {
 
   const openUpdateWizard = () => {
     history.push({
-      pathname: history.location.pathname,
+      pathname,
       search: new URLSearchParams({
         update_image: true,
       }).toString(),
@@ -64,7 +65,7 @@ const ImageVersionDetail = ({ data, imageVersion }) => {
         >
           <UpdateImageWizard
             navigateBack={() => {
-              history.push({ pathname: history.location.pathname });
+              history.push({ pathname });
               setIsUpdateWizardOpen(false);
             }}
             updateimageVersionId={data?.ID}

--- a/src/Routes/ImageManagerDetail/ImageVersionsTab.js
+++ b/src/Routes/ImageManagerDetail/ImageVersionsTab.js
@@ -78,7 +78,7 @@ const createRows = (data, imageSetId, latestImageVersion) => {
       {
         title: (
           <Link
-            to={`${paths['manage-images']}/${imageSetId}/versions/${image.ID}/details`}
+            to={`${paths.manageImages}/${imageSetId}/versions/${image.ID}/details`}
           >
             {image?.Version}
           </Link>

--- a/src/Routes/ImageManagerDetail/__snapshots__/ImageVersionsTab.test.js.snap
+++ b/src/Routes/ImageManagerDetail/__snapshots__/ImageVersionsTab.test.js.snap
@@ -33,9 +33,9 @@ exports[`ImageVersionsTab renders correctly 1`] = `
             <button
               aria-expanded="false"
               aria-label="Options menu"
-              aria-labelledby=" pf-select-toggle-id-0"
+              aria-labelledby=" pf-select-toggle-id-1"
               class="pf-c-select__toggle"
-              id="pf-select-toggle-id-0"
+              id="pf-select-toggle-id-1"
               type="button"
             >
               <div
@@ -78,7 +78,7 @@ exports[`ImageVersionsTab renders correctly 1`] = `
           data-ouia-component-type="PF4/Pagination"
           data-ouia-safe="true"
           data-testid="pagination-header-test-id"
-          id="pagination-options-menu-top-0"
+          id="pagination-options-menu-top-2"
           style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
         >
           <div
@@ -131,7 +131,7 @@ exports[`ImageVersionsTab renders correctly 1`] = `
                 data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
-                id="pagination-options-menu-top-toggle-0"
+                id="pagination-options-menu-top-toggle-2"
                 type="button"
               >
                 <span
@@ -222,7 +222,7 @@ exports[`ImageVersionsTab renders correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-0"
+      id="toolbar-header-expandable-content-3"
     >
       <div
         class="pf-c-toolbar__group"
@@ -241,7 +241,7 @@ exports[`ImageVersionsTab renders correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-1"
+      id="toolbar-header-expandable-content-4"
     >
       <div
         class="pf-c-toolbar__group"

--- a/src/Routes/Repositories/Repositories.js
+++ b/src/Routes/Repositories/Repositories.js
@@ -7,12 +7,12 @@ import Main from '@redhat-cloud-services/frontend-components/Main';
 import RepositoryHeader from './RepositoryHeader';
 import useApi from '../../hooks/useApi';
 import { getCustomRepositories } from '../../api/repositories';
-import { useHistory } from 'react-router-dom';
-import { emptyStateNoFliters } from '../../utils';
+import { useLocation } from 'react-router-dom';
+import { emptyStateNoFilters } from '../../utils';
 import EmptyState from '../../components/Empty';
 
 const Repository = () => {
-  const history = useHistory();
+  const { search } = useLocation();
   const [response, fetchRepos] = useApi({
     api: ({ query }) =>
       getCustomRepositories({
@@ -57,7 +57,7 @@ const Repository = () => {
       <RepositoryHeader />
       <Main>
         <>
-          {!emptyStateNoFliters(isLoading, data?.count, history) ? (
+          {!emptyStateNoFilters(isLoading, data?.count, search) ? (
             <RepositoryTable
               data={data?.data || []}
               count={data?.count}

--- a/src/Routes/Repositories/__snapshots__/RepositoryTable.test.js.snap
+++ b/src/Routes/Repositories/__snapshots__/RepositoryTable.test.js.snap
@@ -88,7 +88,7 @@ exports[`RepositoryTable renders correctly 1`] = `
           data-ouia-component-type="PF4/Pagination"
           data-ouia-safe="true"
           data-testid="pagination-header-test-id"
-          id="pagination-options-menu-top-0"
+          id="pagination-options-menu-top-2"
           style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
         >
           <div
@@ -141,7 +141,7 @@ exports[`RepositoryTable renders correctly 1`] = `
                 data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
-                id="pagination-options-menu-top-toggle-0"
+                id="pagination-options-menu-top-toggle-2"
                 type="button"
               >
                 <span
@@ -232,7 +232,7 @@ exports[`RepositoryTable renders correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-0"
+      id="toolbar-header-expandable-content-3"
     >
       <div
         class="pf-c-toolbar__group"
@@ -251,7 +251,7 @@ exports[`RepositoryTable renders correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-1"
+      id="toolbar-header-expandable-content-4"
     >
       <div
         class="pf-c-toolbar__group"

--- a/src/components/ImageInformationCard.js
+++ b/src/components/ImageInformationCard.js
@@ -51,7 +51,7 @@ const ImageInformationCard = () => {
               <Skeleton size={SkeletonSize.sm} />
             ) : imageData ? (
               <Link
-                to={`${paths['manage-images']}/${imageData?.Image?.ImageSetID}/details`}
+                to={`${paths.manageImages}/${imageData?.Image?.ImageSetID}/details`}
               >
                 {imageData?.Image?.Name}
               </Link>
@@ -65,7 +65,7 @@ const ImageInformationCard = () => {
               <Skeleton size={SkeletonSize.sm} />
             ) : imageData ? (
               <Link
-                to={`${paths['manage-images']}/${imageData?.Image?.ImageSetID}/versions/${imageData?.Image?.ID}/details`}
+                to={`${paths.manageImages}/${imageData?.Image?.ImageSetID}/versions/${imageData?.Image?.ID}/details`}
               >
                 {imageData?.Image?.Version}
               </Link>
@@ -79,7 +79,7 @@ const ImageInformationCard = () => {
               <Skeleton size={SkeletonSize.sm} />
             ) : imageData?.UpdatesAvailable ? (
               <Link
-                to={`${paths['manage-images']}/${imageData?.UpdatesAvailable[0]?.Image?.ImageSetID}/versions/${imageData?.UpdatesAvailable[0]?.Image?.ID}/details`}
+                to={`${paths.manageImages}/${imageData?.UpdatesAvailable[0]?.Image?.ImageSetID}/versions/${imageData?.UpdatesAvailable[0]?.Image?.ID}/details`}
               >
                 {imageData?.UpdatesAvailable[0]?.Image?.Version}
               </Link>
@@ -95,7 +95,7 @@ const ImageInformationCard = () => {
               <Skeleton size={SkeletonSize.sm} />
             ) : imageData?.RollbackImage?.ID ? (
               <Link
-                to={`${paths['manage-images']}/${imageData?.RollbackImage?.ImageSetID}/versions/${imageData?.RollbackImage?.ID}/details`}
+                to={`${paths.manageImages}/${imageData?.RollbackImage?.ImageSetID}/versions/${imageData?.RollbackImage?.ID}/details`}
               >
                 {imageData?.RollbackImage?.Version}
               </Link>

--- a/src/components/form/WizardRepositoryTable.js
+++ b/src/components/form/WizardRepositoryTable.js
@@ -75,7 +75,7 @@ const WizardRepositoryTable = (props) => {
           body="Add custom repositories to build RHEL for Edge images with additional packages."
           primaryAction={{
             text: 'Custom repositories',
-            href: paths['repositories'],
+            href: paths.repositories,
           }}
         />
       ) : (

--- a/src/components/general-table/GeneralTable.js
+++ b/src/components/general-table/GeneralTable.js
@@ -14,7 +14,7 @@ import CustomEmptyState from '../Empty';
 import { useDispatch } from 'react-redux';
 import { transformSort } from '../../utils';
 import BulkSelect from './BulkSelect';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { stateToUrlSearch } from '../../utils';
 
 const filterParams = (chipsArray) => {
@@ -83,16 +83,21 @@ const GeneralTable = ({
   const [checkedRows, setCheckedRows] = useState(defaultCheckedRows);
   const dispatch = useDispatch();
   const history = useHistory();
+  const { pathname, search } = useLocation();
 
   useEffect(() => {
+    // Add or remove has_filters param depending on whether filters are present
     if (
-      //!history.location.search.includes('add_system_modal=true') &&
-      !history.location.search.includes('create_image=true') &&
-      !history.location.search.includes('update_image=true')
+      !search.includes('create_image=true') &&
+      !search.includes('update_image=true')
     ) {
-      history.push({
-        pathname: history.location.pathname,
-        search: stateToUrlSearch('has_filters=true', chipsArray.length > 0),
+      history.replace({
+        pathname,
+        search: stateToUrlSearch(
+          'has_filters=true',
+          chipsArray.length > 0,
+          search
+        ),
       });
     }
 

--- a/src/components/general-table/__snapshots__/GeneralTable.test.js.snap
+++ b/src/components/general-table/__snapshots__/GeneralTable.test.js.snap
@@ -31,9 +31,9 @@ exports[`General table should render correctly 1`] = `
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Options menu"
-            aria-labelledby=" pf-select-toggle-id-0"
+            aria-labelledby=" pf-select-toggle-id-1"
             class="pf-c-select__toggle"
-            id="pf-select-toggle-id-0"
+            id="pf-select-toggle-id-1"
             type="button"
           >
             <div
@@ -154,7 +154,7 @@ exports[`General table should render correctly 1`] = `
           data-ouia-component-type="PF4/Pagination"
           data-ouia-safe="true"
           data-testid="pagination-header-test-id"
-          id="pagination-options-menu-top-0"
+          id="pagination-options-menu-top-2"
           style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
         >
           <div
@@ -207,7 +207,7 @@ exports[`General table should render correctly 1`] = `
                 data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
-                id="pagination-options-menu-top-toggle-0"
+                id="pagination-options-menu-top-toggle-2"
                 type="button"
               >
                 <span
@@ -298,7 +298,7 @@ exports[`General table should render correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-0"
+      id="toolbar-header-expandable-content-3"
     >
       <div
         class="pf-c-toolbar__group"
@@ -317,7 +317,7 @@ exports[`General table should render correctly 1`] = `
     </div>
     <div
       class="pf-c-toolbar__expandable-content"
-      id="toolbar-header-expandable-content-1"
+      id="toolbar-header-expandable-content-4"
     >
       <div
         class="pf-c-toolbar__group"

--- a/src/constants/routeMapper.js
+++ b/src/constants/routeMapper.js
@@ -1,21 +1,19 @@
 export const routes = {
   groups: '/groups',
-  'groups-detail': '/groups/:uuid',
-  'device-detail': '/groups/:uuid/:inventoryId',
+  groupsDetail: '/groups/:uuid',
+  deviceDetail: '/groups/:uuid/:inventoryId',
   canaries: '/canaries',
-  'fleet-management': '/fleet-management',
-  'fleet-management-detail': '/fleet-management/:groupId',
-  'fleet-management-system-detail':
-    '/fleet-management/:groupId/systems/:deviceId',
-  'fleet-management-system-detail-update':
+  fleetManagement: '/fleet-management',
+  fleetManagementDetail: '/fleet-management/:groupId',
+  fleetManagementSystemDetail: '/fleet-management/:groupId/systems/:deviceId',
+  fleetManagementSystemDetailUpdate:
     '/fleet-management/:groupId/systems/:deviceId/update',
   inventory: '/inventory',
-  'inventory-detail': '/inventory/:deviceId',
-  'inventory-detail-update': '/inventory/:deviceId/update',
-  'manage-images': '/manage-images',
-  'manage-images-detail': '/manage-images/:imageId',
-  'manage-images-detail-version':
-    '/manage-images/:imageId/versions/:imageVersionId',
+  inventoryDetail: '/inventory/:deviceId',
+  inventoryDetailUpdate: '/inventory/:deviceId/update',
+  manageImages: '/manage-images',
+  manageImagesDetail: '/manage-images/:imageId',
+  manageImagesDetailVersion: '/manage-images/:imageId/versions/:imageVersionId',
   repositories: '/repositories',
-  'learning-resources': '/learning-resources',
+  learningResources: '/learning-resources',
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -29,15 +29,15 @@ export const mapUrlToObj = (url, keys) => {
   return obj;
 };
 
-//urlString is the string added to the url search param
-//state is a boolean that adds or removes the urlString from the url
-export const stateToUrlSearch = (urlString, state) => {
+// urlString is the string added to the url search param
+// state is a boolean that adds or removes the urlString from the url
+export const stateToUrlSearch = (urlString, state, search) => {
   var searchArray = [];
   const currentSearchArray =
-    location.search.length > 0
-      ? location.search.includes('&')
-        ? location.search.split('?')[1].split('&')
-        : location.search.split('?').slice(1)
+    search.length > 0
+      ? search.includes('&')
+        ? search.split('?')[1].split('&')
+        : search.split('?').slice(1)
       : [];
   if (state) {
     currentSearchArray.includes(urlString)
@@ -53,10 +53,8 @@ export const stateToUrlSearch = (urlString, state) => {
   return searchArray.join('&');
 };
 
-export const emptyStateNoFliters = (isLoading, count, history) =>
-  isLoading !== true &&
-  !count > 0 &&
-  !history.location.search.includes('has_filters=true');
+export const emptyStateNoFilters = (isLoading, count, search) =>
+  isLoading !== true && !count > 0 && !search.includes('has_filters=true');
 
 export const canUpdateSelectedDevices = ({ deviceData, imageData }) =>
   deviceData?.length > 0 && imageData


### PR DESCRIPTION
# Description

Currently, the `handleClose` event handler in `UpdateVersionTable.js` is hard-coded to go back to the Inventory page after clicking `Update system` or `Cancel`. That's shouldn't be the case when updating from the system details page or group details page. This PR changes `handleClose` to redirect to the correct page.

Cases to check:
1. Update from kebab in Inventory should go back to Inventory.
2. Update from kebab in group details page should go back to group details page.
3. Update from actions dropdown in Inventory > systems details page should go back to systems details page.
4. Update from actions dropdown in group details > systems details page should go back to systems details page.

This PR also makes the following changes:
- Fixed Breadcrumbs when updating system from group details
- Removed deprecated call to `insights.chrome.init` (THEEDGE-2910)
- Fixed an issue in which loading a page results in multiple duplicate browser history entries (THEEDGE-2945)
- Updated `routes`/`paths` object to use camel case keys consistently, e.g., `paths.fleetManagement` instead of `paths['fleet-management']`.


Fixes # (issue)
[THEEDGE-2910](https://issues.redhat.com/browse/THEEDGE-2910)
[THEEDGE-2929](https://issues.redhat.com/browse/THEEDGE-2929)
[THEEDGE-2945](https://issues.redhat.com/browse/THEEDGE-2945)


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [X] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted