### PR TITLE
THEEDGE-2922 reloading data after update from image details page

### DIFF
--- a/src/Routes/ImageManagerDetail/ImageDetail.js
+++ b/src/Routes/ImageManagerDetail/ImageDetail.js
@@ -49,6 +49,10 @@ const ImageDetail = () => {
     fetchImageSetDetails();
   }, [imageId, imageVersionId]);
 
+  const reload = async () => {
+    await fetchImageSetDetails();
+  };
+
   return (
     <Fragment>
       <PageHeader className="pf-m-light">
@@ -83,6 +87,7 @@ const ImageDetail = () => {
               setUpdateWizard((prevState) => ({ ...prevState, isOpen: false }));
             }}
             updateImageID={updateWizard.updateId}
+            reload={reload}
           />
         </Suspense>
       )}


### PR DESCRIPTION
# Description

Currently when updating an image from image details page, the status is not refreshed to Updating. This PR is adding a function that reloads the data automatically.

Fixes # 
[THEEDGE-2922](https://issues.redhat.com/browse/THEEDGE-2922)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted