### PR TITLE
Remove deprecated insights.chrome.init call

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,8 +14,6 @@ const App = (props) => {
   const history = useHistory();
   const [isAuth, setIsAuth] = useState(null);
   useEffect(() => {
-    insights.chrome.init();
-    // TODO change this to your appname
     insights.chrome.identifyApp('fleet-management');
 
     insights.chrome.on('APP_NAVIGATION', (event) =>


### PR DESCRIPTION
# Description

With the latest build of insights-chrome now in prod, we can remove the deprecated call to `insights.chrome.init` from `App`. UI functionality is unchanged. The only difference is that the browser console will no longer show errors like the following:

```
Calling deprecated "chrome.init function"! Please remove the function call from your code. Functions "on" and "updateDocumentTitle" are directly accessible from "useChrome" hook.
```

Fixes # ([THEEDGE-2910](https://issues.redhat.com/browse/THEEDGE-2910))

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted