### PR TITLE
THEEDGE-2896 - Fix typo on toast notifications while creating images

### DIFF
--- a/src/Routes/ImageManager/CreateImageWizard.js
+++ b/src/Routes/ImageManager/CreateImageWizard.js
@@ -60,7 +60,7 @@ const CreateImage = ({ navigateBack, reload }) => {
           dispatch({
             ...addNotification({
               variant: 'info',
-              title: 'Created image',
+              title: 'Creating image',
               description: `${resp.value.Name} image was added to the queue.`,
             }),
             meta: {


### PR DESCRIPTION
# Description

This PR is changing the toast notification title when creating an image from **Created image** to **Creating image**

Fixes # (issue)
[THEEDGE-2896](https://issues.redhat.com/browse/THEEDGE-2896)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted