### PR TITLE
THEEDGE-2983 - changing toast notification when update an image to Updating image

### DIFF
--- a/src/Routes/DeviceDetail/UpdateImageModal.js
+++ b/src/Routes/DeviceDetail/UpdateImageModal.js
@@ -15,13 +15,16 @@ import {
 } from '@patternfly/react-core';
 import { imageTypeMapper, releaseMapper } from '../../constants';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
-import { useSelector, shallowEqual } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { imageDetailReducer } from '../../store/reducers';
-import { loadImageDetail, loadEdgeImageSets } from '../../store/actions';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { createNewImage, addImageToPoll } from '../../store/actions';
+import {
+  createNewImage,
+  addImageToPoll,
+  loadImageDetail,
+  loadEdgeImageSets,
+} from '../../store/actions';
 import { getEdgeImageStatus } from '../../api/images';
 
 const UpdateImageModal = ({ updateCveModal, setUpdateCveModal, setReload }) => {
@@ -65,7 +68,7 @@ const UpdateImageModal = ({ updateCveModal, setUpdateCveModal, setReload }) => {
       dispatch({
         ...addNotification({
           variant: 'info',
-          title: 'Update image',
+          title: 'Updating image',
           description: `${resp.value.Name} image was added to the queue.`,
         }),
         meta: {
@@ -126,7 +129,6 @@ const UpdateImageModal = ({ updateCveModal, setUpdateCveModal, setReload }) => {
       description="Review the information and click Update image to start the build process"
       isOpen={updateCveModal.isOpen}
       onClose={handleClose}
-      //onSubmit={handleUpdateModal}
       actions={[
         <Button key="confirm" variant="primary" onClick={handleUpdateModal}>
           Update Image

--- a/src/Routes/ImageManager/UpdateImageWizard.js
+++ b/src/Routes/ImageManager/UpdateImageWizard.js
@@ -13,12 +13,14 @@ import {
 import { Bullseye, Backdrop, Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import ReviewStep from '../../components/form/ReviewStep';
-import { createNewImage, addImageToPoll } from '../../store/actions';
-import { useDispatch } from 'react-redux';
-import { useSelector, shallowEqual } from 'react-redux';
+import {
+  createNewImage,
+  addImageToPoll,
+  loadImageDetail,
+} from '../../store/actions';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { RegistryContext } from '../../store';
 import { imageDetailReducer } from '../../store/reducers';
-import { loadImageDetail } from '../../store/actions';
 import { getEdgeImageStatus } from '../../api/images';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useFeatureFlags, getReleases } from '../../utils';
@@ -85,7 +87,7 @@ const UpdateImage = ({ navigateBack, updateImageID, reload }) => {
           dispatch({
             ...addNotification({
               variant: 'info',
-              title: 'Update image',
+              title: 'Updating image',
               description: `${resp.value.Name} image was added to the queue.`,
             }),
             meta: {


### PR DESCRIPTION
# Description

When update an image the toast notification shows `Update image...` This PR is changing the text to `Updating image...` to make more sense to the user.

Fixes # ([THEEDGE-2983](https://issues.redhat.com/browse/THEEDGE-2983))

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [X] Tests update

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted