### PR TITLE
THEEDGE-2918 - Closing AuthModal redirects user to Prod regardless of env

### DIFF
--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -8,7 +8,7 @@ const AuthModal = () => {
       style={{ padding: '15px' }}
       isOpen={true}
       variant="small"
-      onClose={() => (window.location.href = 'https://console.redhat.com/')}
+      onClose={() => (window.location.href = `https://${window.location.host}`)}
       aria-label="auth-modal"
       header={
         <h2 className="pf-u-pr-xl pf-u-pl-xl pf-u-font-size-2xl pf-u-text-align-center pf-u-font-weight-bold">
@@ -49,7 +49,7 @@ const AuthModal = () => {
             component="a"
             key="not-now"
             variant="link"
-            href="https://console.redhat.com/"
+            href={`https://${window.location.host}`}
           >
             Not now
           </Button>


### PR DESCRIPTION
# Description

Current behavior when closing Auth Modal is navigation to [console.redhat.com](http://console.redhat.com/) because it's hardcoded. This PR is changing  `window.location.href`  from `https://console.redhat.com/` to `https://${window.location.host}`

Fixes # ([THEEDGE-2918](https://issues.redhat.com/browse/THEEDGE-2918))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [X] Tests update

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted