### PR TITLE
add check to see if there were additional loading to be done for system entity

### DIFF
--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -46,6 +46,7 @@ const DeviceDetail = () => {
   const { deviceId, groupId } = useParams();
   const [imageId, setImageId] = useState(null);
   const { getRegistry } = useContext(RegistryContext);
+  const hasEntityFinishedLoaded = useSelector((store) => store?.entityDetails?.loaded);
   const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
 
   const [imageData, setImageData] = useState();
@@ -206,7 +207,7 @@ const DeviceDetail = () => {
           />
         )}
       </PageHeader>
-      {entity && (
+      {hasEntityFinishedLoaded && (
         <DeviceDetailTabs
           systemProfile={imageData}
           imageId={imageId}

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -46,7 +46,9 @@ const DeviceDetail = () => {
   const { deviceId, groupId } = useParams();
   const [imageId, setImageId] = useState(null);
   const { getRegistry } = useContext(RegistryContext);
-  const hasEntityFinishedLoading = useSelector((store) => store?.entityDetails?.loaded);
+  const hasEntityFinishedLoading = useSelector(
+    (store) => store?.entityDetails?.loaded
+  );
   const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
 
   const [imageData, setImageData] = useState();

--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -46,7 +46,7 @@ const DeviceDetail = () => {
   const { deviceId, groupId } = useParams();
   const [imageId, setImageId] = useState(null);
   const { getRegistry } = useContext(RegistryContext);
-  const hasEntityFinishedLoaded = useSelector((store) => store?.entityDetails?.loaded);
+  const hasEntityFinishedLoading = useSelector((store) => store?.entityDetails?.loaded);
   const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
 
   const [imageData, setImageData] = useState();
@@ -207,7 +207,7 @@ const DeviceDetail = () => {
           />
         )}
       </PageHeader>
-      {hasEntityFinishedLoaded && (
+      {hasEntityFinishedLoading && (
         <DeviceDetailTabs
           systemProfile={imageData}
           imageId={imageId}


### PR DESCRIPTION
# Description

In system details page view the image information and operating system cards were receiving outdated information. This was due to rendering before the redux store was finished updating. 

- Added check to update view for every update to entity

Fixes # (issue)

## Type of change

What is it?

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted