### PR TITLE
changing custom packages search aria-label

### DIFF
--- a/src/components/form/AdditionalCustomPackages.js
+++ b/src/components/form/AdditionalCustomPackages.js
@@ -308,7 +308,7 @@ const AdditionalCustomPackages = ({ defaultArch, ...props }) => {
               onClick={handlePackageSearch}
               isDisabled={!isAvailable}
               variant="control"
-              aria-label="search button for additional custom packages"
+              aria-label="search button for search input"
               data-testid="package-search"
             >
               <ArrowRightIcon />


### PR DESCRIPTION
# Description

This MR is changing aria-label for custom packages search button to _`search button for search input`_ to match [widget for the dual-list-selector pane](https://gitlab.cee.redhat.com/insights-qe/iqe-edge-plugin/-/blob/master/iqe_edge/widgetastic_iqe/__init__.py#L244)

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted