### PR TITLE
Add documentation link to Edge repositories splash page

### DIFF
--- a/src/Routes/Repositories/RepositoryLinkAccess.js
+++ b/src/Routes/Repositories/RepositoryLinkAccess.js
@@ -4,6 +4,8 @@ import {
   EmptyState,
   EmptyStateIcon,
   EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Icon,
   TextContent,
   Text,
   Title,
@@ -39,6 +41,25 @@ const RepositoryLinkAccess = () => (
       >
         Go to Repositories
       </Button>
+      <EmptyStateSecondaryActions>
+        <Button
+          id="moved-state-link"
+          variant="link"
+          component="a"
+          target="_blank"
+          href="https://access.redhat.com/documentation/en-us/edge_management/2022/html-single/create_rhel_for_edge_images_and_configure_automated_management/index#proc_rhem-create-custom-repos"
+        >
+          Learn more about custom repositories
+          <Icon
+            style={{ paddingLeft: '1rem' }}
+            iconSize="md"
+            size="lg"
+            isInline
+          >
+            <ExternalLinkAltIcon />
+          </Icon>
+        </Button>
+      </EmptyStateSecondaryActions>
     </EmptyState>
   </>
 );


### PR DESCRIPTION
# Description

Adding link to custom repos documentation: https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/proc_rhem-create-custom-repos

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted