### PR TITLE
THEEDGE-3363: Allow configuring API hostname locally for stage/dev environment

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -6,6 +6,8 @@ const insightsProxy = {
   ...(process.env.BETA && { deployment: 'beta/apps' }),
 };
 
+const hostname = process.env.API_HOSTNAME ?? 'localhost';
+
 const webpackProxy = {
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
   useProxy: true,
@@ -18,11 +20,11 @@ const webpackProxy = {
   }),
   routes: {
     ...(process.env.API_PORT && {
-      '/api/edge': { host: `http://localhost:${process.env.API_PORT}` },
+      '/api/edge': { host: `http://${hostname}:${process.env.API_PORT}` },
     }),
     ...(process.env.CONFIG_PORT && {
       [`${process.env.BETA ? '/beta' : ''}/config`]: {
-        host: `http://localhost:${process.env.CONFIG_PORT}`,
+        host: `http://${hostname}:${process.env.CONFIG_PORT}`,
       },
     }),
   },


### PR DESCRIPTION
# Description
Currently, the API hostname is hardcoded as `localhost`; this allows configuring it as an environment variable for the stage environment locally.

Fixes # (issue)

Fixes [THEEDGE-3363](https://issues.redhat.com/browse/THEEDGE-3363)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted