### PR TITLE
remove image title in some case

### DIFF
--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -1,9 +1,9 @@
 import React, { Fragment, useState, Suspense } from 'react';
+import { Spinner, Bullseye } from '@patternfly/react-core';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { Spinner, Bullseye } from '@patternfly/react-core';
 import { useHistory, useLocation, useNavigate } from 'react-router-dom';
 import ImageSetsTable from './ImageSetsTable';
 import { stateToUrlSearch } from '../../utils';
@@ -28,6 +28,7 @@ const Images = ({
   locationProp,
   navigateProp,
   notificationProp,
+  showHeaderProp,
 }) => {
   const history = historyProp
     ? historyProp()
@@ -40,7 +41,7 @@ const Images = ({
     ? useNavigate()
     : null;
   const { pathname, search } = locationProp ? locationProp() : useLocation();
-
+  const showHeader = showHeaderProp === undefined ? true : showHeaderProp;
   const [response, fetchImageSets] = useApi({
     api: getImageSets,
     tableReload: true,
@@ -93,9 +94,11 @@ const Images = ({
 
   return (
     <Fragment>
-      <PageHeader className="pf-m-light">
-        <PageHeaderTitle title="Images" />
-      </PageHeader>
+      {showHeader && (
+        <PageHeader className="pf-m-light">
+          <PageHeaderTitle title="Images" />
+        </PageHeader>
+      )}
       <section className="edge-images pf-l-page__main-section pf-c-page__main-section">
         <ImageSetsTable
           historyProp={historyProp}
@@ -177,5 +180,6 @@ Images.propTypes = {
   locationProp: PropTypes.func,
   navigateProp: PropTypes.func,
   notificationProp: PropTypes.object,
+  showHeaderProp: PropTypes.bool,
 };
 export default Images;


### PR DESCRIPTION
 Description

this pr will remove the 'images' title in case we use federation mode in other services  - 

<img width="1857" alt="Screenshot 2023-06-08 at 14 47 57" src="https://github.com/RedHatInsights/edge-frontend/assets/73419853/3a7828fe-f47c-49d0-a0b1-2b9587f4ae5a">


related to the ticket- 
https://issues.redhat.com/browse/THEEDGE-3373
## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted