### PR TITLE
image-set-details: FIXES restorePrefixURL function.

### DIFF
--- a/src/Routes/ImageManagerDetail/utils.js
+++ b/src/Routes/ImageManagerDetail/utils.js
@@ -14,10 +14,14 @@ const getBaseURLFromPrefixAndName = (defaultBaseURL, pathPrefix, urlName) => {
 };
 
 const restorePrefixURL = (url, pathPrefix) => {
+  const separator = '/';
   if (!pathPrefix || url.startsWith(pathPrefix)) {
     return url;
   }
-  return [pathPrefix, url].join('/');
+  if (pathPrefix.endsWith(separator) || url.startsWith(separator)) {
+    return [pathPrefix, url].join('');
+  }
+  return [pathPrefix, url].join(separator);
 };
 
 export { getBaseURLFromPrefixAndName, restorePrefixURL };


### PR DESCRIPTION
# Description

This Fixes the join of url parts when one of the part is starting or ending with url separator. in local dev it was working ok, but this raised in stage.

FiXES: THEEDGE-3409

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted