### PR TITLE
feat: create new federated module to expose ImageDeatilsCard

### DIFF
--- a/.husky/pre-commit 2
+++ b/.husky/pre-commit 2
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+ 
+if npm run lint:js:fix; then
+  git add -A .
+else
+  echo "Lint failed, fix lint and retry committing"
+  exit 1
+fi

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -61,7 +61,10 @@ plugins.push(
           __dirname,
           '../src/Routes/ImageManagerDetail/ImageDetail.js'
         ),
-
+        './ImagesInformationCard': resolve(
+          __dirname,
+          '../src/components/ImageInformationCard.js'
+        ),
         './DeviceTable': resolve(
           __dirname,
           '../src/Routes/Devices/DeviceTable.js'

--- a/fec.config 2.js
+++ b/fec.config 2.js
@@ -1,0 +1,3 @@
+module.exports = {
+    appUrl: '/edge',
+  };

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -115,6 +115,8 @@ const createRows = (
       </div>
     );
 
+    const pathToDevice = deviceLinkBase !== 'federated' ? `${deviceLinkBase}/${DeviceUUID}` : `/${DeviceUUID}`;
+    
     return {
       rowInfo: {
         deviceID: DeviceID,
@@ -141,7 +143,7 @@ const createRows = (
         {
           title: hasLinks
             ? createLink({
-                pathname: `${deviceBaseUrl}/${DeviceUUID}`,
+                pathname: pathToDevice,
                 linkText: DeviceName,
                 history,
                 navigate,
@@ -247,8 +249,8 @@ const DeviceTable = ({
     : null;
 
   // Create base URL path for system detail link
-  const deviceBaseUrl =
-    pathname === paths.inventory
+  const deviceBaseUrl = historyProp ? 'federated' : 
+    pathname ===  paths.inventory
       ? pathname
       : pathname === '/'
       ? ''

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -115,8 +115,10 @@ const createRows = (
       </div>
     );
 
-    const pathToDevice = deviceLinkBase !== 'federated' ? `${deviceLinkBase}/${DeviceUUID}` : `/${DeviceUUID}`;
-    
+    const pathToDevice =
+      deviceBaseUrl !== 'federated'
+        ? `${deviceBaseUrl}/${DeviceUUID}`
+        : `/${DeviceUUID}`;
     return {
       rowInfo: {
         deviceID: DeviceID,
@@ -249,12 +251,13 @@ const DeviceTable = ({
     : null;
 
   // Create base URL path for system detail link
-  const deviceBaseUrl = historyProp ? 'federated' : 
-    pathname ===  paths.inventory
-      ? pathname
-      : pathname === '/'
-      ? ''
-      : `${pathname}/systems`;
+  const deviceBaseUrl = historyProp
+    ? 'federated'
+    : pathname === paths.inventory
+    ? pathname
+    : pathname === '/'
+    ? ''
+    : `${pathname}/systems`;
 
   const actionResolver = (rowData) => {
     const getUpdatePathname = (updateRowData) =>

--- a/src/components/ImageInformationCard.js
+++ b/src/components/ImageInformationCard.js
@@ -19,8 +19,8 @@ const LoadingCard = (props) => (
   />
 );
 
-const ImageInformationCard = () => {
-  const deviceId = useSelector(
+const ImageInformationCard = ({deviceIdProps}) => {
+  const deviceId = deviceIdProps ?? useSelector(
     ({ entityDetails }) => entityDetails?.entity?.id
   );
   const [isImageInfoLoading, setIsImageInfoLoading] = useState(true);
@@ -39,73 +39,114 @@ const ImageInformationCard = () => {
     })();
   }, []);
 
+  const edgeImageData = [
+    {
+      title: 'Running image',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData ? (
+        <Link
+          to={`${paths.manageImages}/${imageData?.Image?.ImageSetID}/details`}
+        >
+          {imageData?.Image?.Name}
+        </Link>
+      ) : (
+        'unavailable'
+      ),
+    },
+    {
+      title: 'Running version',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData ? (
+        <Link
+          to={`${paths.manageImages}/${imageData?.Image?.ImageSetID}/versions/${imageData?.Image?.ID}/details`}
+        >
+          {imageData?.Image?.Version}
+        </Link>
+      ) : (
+        'unavailable'
+      ),
+    },
+    {
+      title: 'Target version',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData?.UpdatesAvailable ? (
+        <Link
+          to={`${paths.manageImages}/${imageData?.UpdatesAvailable[0]?.Image?.ImageSetID}/versions/${imageData?.UpdatesAvailable[0]?.Image?.ID}/details`}
+        >
+          {imageData?.UpdatesAvailable[0]?.Image?.Version}
+        </Link>
+      ) : hasError ? (
+        'unavailable'
+      ) : (
+        'Same as running'
+      ),
+    },
+    {
+      title: 'Rollback version',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData?.RollbackImage?.ID ? (
+        <Link
+          to={`${paths.manageImages}/${imageData?.RollbackImage?.ImageSetID}/versions/${imageData?.RollbackImage?.ID}/details`}
+        >
+          {imageData?.RollbackImage?.Version}
+        </Link>
+      ) : hasError ? (
+        'unavailable'
+      ) : (
+        'None'
+      ),
+    },
+  ];
+
+  const federatedImageData = [
+    {
+      title: 'Running image',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData ? imageData?.Image?.Name : (
+        'unavailable'
+      ),
+    },
+    {
+      title: 'Running version',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData ? imageData?.Image?.Version : (
+        'unavailable'
+      ),
+    },
+    {
+      title: 'Target version',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData?.UpdatesAvailable ? imageData?.UpdatesAvailable[0]?.Image?.Version : hasError ? (
+        'unavailable'
+      ) : (
+        'Same as running'
+      ),
+    },
+    {
+      title: 'Rollback version',
+      value: isImageInfoLoading ? (
+        <Skeleton size={SkeletonSize.sm} />
+      ) : imageData?.RollbackImage?.ID ? imageData?.RollbackImage?.Version : hasError ? (
+        'unavailable'
+      ) : (
+        'None'
+      ),
+    },
+  ];
+
   return (
     <Suspense fallback="">
       <LoadingCard
         title="Image information"
         isLoading={false}
-        items={[
-          {
-            title: 'Running image',
-            value: isImageInfoLoading ? (
-              <Skeleton size={SkeletonSize.sm} />
-            ) : imageData ? (
-              <Link
-                to={`${paths.manageImages}/${imageData?.Image?.ImageSetID}/details`}
-              >
-                {imageData?.Image?.Name}
-              </Link>
-            ) : (
-              'unavailable'
-            ),
-          },
-          {
-            title: 'Running version',
-            value: isImageInfoLoading ? (
-              <Skeleton size={SkeletonSize.sm} />
-            ) : imageData ? (
-              <Link
-                to={`${paths.manageImages}/${imageData?.Image?.ImageSetID}/versions/${imageData?.Image?.ID}/details`}
-              >
-                {imageData?.Image?.Version}
-              </Link>
-            ) : (
-              'unavailable'
-            ),
-          },
-          {
-            title: 'Target version',
-            value: isImageInfoLoading ? (
-              <Skeleton size={SkeletonSize.sm} />
-            ) : imageData?.UpdatesAvailable ? (
-              <Link
-                to={`${paths.manageImages}/${imageData?.UpdatesAvailable[0]?.Image?.ImageSetID}/versions/${imageData?.UpdatesAvailable[0]?.Image?.ID}/details`}
-              >
-                {imageData?.UpdatesAvailable[0]?.Image?.Version}
-              </Link>
-            ) : hasError ? (
-              'unavailable'
-            ) : (
-              'Same as running'
-            ),
-          },
-          {
-            title: 'Rollback version',
-            value: isImageInfoLoading ? (
-              <Skeleton size={SkeletonSize.sm} />
-            ) : imageData?.RollbackImage?.ID ? (
-              <Link
-                to={`${paths.manageImages}/${imageData?.RollbackImage?.ImageSetID}/versions/${imageData?.RollbackImage?.ID}/details`}
-              >
-                {imageData?.RollbackImage?.Version}
-              </Link>
-            ) : hasError ? (
-              'unavailable'
-            ) : (
-              'None'
-            ),
-          },
-        ]}
+        items={deviceIdProps ? federatedImageData : edgeImageData}
       />
     </Suspense>
   );

--- a/src/components/ImageInformationCard.js
+++ b/src/components/ImageInformationCard.js
@@ -9,6 +9,7 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import CmpLoader from './CmpLoader';
+import PropTypes from 'prop-types';
 
 const LoadingCard = (props) => (
   <AsyncComponent
@@ -19,10 +20,10 @@ const LoadingCard = (props) => (
   />
 );
 
-const ImageInformationCard = ({deviceIdProps}) => {
-  const deviceId = deviceIdProps ?? useSelector(
-    ({ entityDetails }) => entityDetails?.entity?.id
-  );
+const ImageInformationCard = ({ deviceIdProps }) => {
+  const deviceId =
+    deviceIdProps ??
+    useSelector(({ entityDetails }) => entityDetails?.entity?.id);
   const [isImageInfoLoading, setIsImageInfoLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [imageData, setImageData] = useState(null);
@@ -107,7 +108,9 @@ const ImageInformationCard = ({deviceIdProps}) => {
       title: 'Running image',
       value: isImageInfoLoading ? (
         <Skeleton size={SkeletonSize.sm} />
-      ) : imageData ? imageData?.Image?.Name : (
+      ) : imageData ? (
+        imageData?.Image?.Name
+      ) : (
         'unavailable'
       ),
     },
@@ -115,7 +118,9 @@ const ImageInformationCard = ({deviceIdProps}) => {
       title: 'Running version',
       value: isImageInfoLoading ? (
         <Skeleton size={SkeletonSize.sm} />
-      ) : imageData ? imageData?.Image?.Version : (
+      ) : imageData ? (
+        imageData?.Image?.Version
+      ) : (
         'unavailable'
       ),
     },
@@ -123,7 +128,9 @@ const ImageInformationCard = ({deviceIdProps}) => {
       title: 'Target version',
       value: isImageInfoLoading ? (
         <Skeleton size={SkeletonSize.sm} />
-      ) : imageData?.UpdatesAvailable ? imageData?.UpdatesAvailable[0]?.Image?.Version : hasError ? (
+      ) : imageData?.UpdatesAvailable ? (
+        imageData?.UpdatesAvailable[0]?.Image?.Version
+      ) : hasError ? (
         'unavailable'
       ) : (
         'Same as running'
@@ -133,7 +140,9 @@ const ImageInformationCard = ({deviceIdProps}) => {
       title: 'Rollback version',
       value: isImageInfoLoading ? (
         <Skeleton size={SkeletonSize.sm} />
-      ) : imageData?.RollbackImage?.ID ? imageData?.RollbackImage?.Version : hasError ? (
+      ) : imageData?.RollbackImage?.ID ? (
+        imageData?.RollbackImage?.Version
+      ) : hasError ? (
         'unavailable'
       ) : (
         'None'
@@ -150,6 +159,10 @@ const ImageInformationCard = ({deviceIdProps}) => {
       />
     </Suspense>
   );
+};
+
+ImageInformationCard.propTypes = {
+  deviceIdProps: PropTypes.string,
 };
 
 export default ImageInformationCard;


### PR DESCRIPTION
…ed by Insights Inventory

# Description

As part of Edge feature parity initiative, this PR will create a federated module for ImageDetailsCard to be used by Insights inventory to show image details for devices (called by them as Inventory).

Fixes # THEEDGE-3359

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted