### PR TITLE
add descrption to landing page when there is no images

### DIFF
--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -209,13 +209,24 @@ const ImageTable = ({
         <CustomEmptyState
           data-testid="general-table-empty-state-no-data"
           icon={'plus'}
-          title={'No images found'}
-          body={''}
+          title={'Create an OSTree image'}
+          body={
+            'Use the image builder tool to compose ' +
+            'customized RHEL (rpm-ostree) images optimized for Edge.' +
+            ' Then, you can remotely install, and securely manage and' +
+            ' scale deployments of the images on Edge servers.'
+          }
           primaryAction={{
             click: openCreateWizard,
             text: 'Create new image',
           }}
-          secondaryActions={[]}
+          secondaryActions={[
+            {
+              type: 'link',
+              title: 'RHEL for Edge image documentation',
+              link: 'https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index',
+            },
+          ]}
         />
       ) : (
         <GeneralTable

--- a/src/Routes/ImageManager/__snapshots__/ImageSetsTable.test.js.snap
+++ b/src/Routes/ImageManager/__snapshots__/ImageSetsTable.test.js.snap
@@ -27,15 +27,17 @@ exports[`ImageSets table to render correctly 1`] = `
       data-ouia-component-type="PF4/Title"
       data-ouia-safe="true"
     >
-      No images found
+      Create an OSTree image
     </h4>
     <div
       class="pf-c-empty-state__body"
-    />
+    >
+      Use the image builder tool to compose customized RHEL (rpm-ostree) images optimized for Edge. Then, you can remotely install, and securely manage and scale deployments of the images on Edge servers.
+    </div>
     <button
       aria-disabled="false"
-      class="pf-c-button pf-m-link"
-      data-ouia-component-id="OUIA-Generated-Button-link-1"
+      class="pf-c-button pf-m-primary"
+      data-ouia-component-id="OUIA-Generated-Button-primary-1"
       data-ouia-component-type="PF4/Button"
       data-ouia-safe="true"
       type="button"
@@ -44,7 +46,33 @@ exports[`ImageSets table to render correctly 1`] = `
     </button>
     <div
       class="pf-c-empty-state__secondary"
-    />
+    >
+      <a
+        aria-disabled="false"
+        class="pf-c-button pf-m-link"
+        data-ouia-component-id="OUIA-Generated-Button-link-1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        href="https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index"
+        target="_blank"
+      >
+        RHEL for Edge image documentation
+        <svg
+          aria-hidden="true"
+          class="pf-u-ml-sm"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+          />
+        </svg>
+      </a>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/Empty.js
+++ b/src/components/Empty.js
@@ -35,7 +35,7 @@ const Empty = ({
             history,
           })
         ) : (
-          <Button variant="link" onClick={primaryAction.click}>
+          <Button variant="primary" onClick={primaryAction.click}>
             {primaryAction.text}
           </Button>
         )}

--- a/src/components/__snapshots__/Empty.test.js.snap
+++ b/src/components/__snapshots__/Empty.test.js.snap
@@ -36,8 +36,8 @@ exports[`Empty renders correctly 1`] = `
     </div>
     <button
       aria-disabled="false"
-      class="pf-c-button pf-m-link"
-      data-ouia-component-id="OUIA-Generated-Button-link-1"
+      class="pf-c-button pf-m-primary"
+      data-ouia-component-id="OUIA-Generated-Button-primary-1"
       data-ouia-component-type="PF4/Button"
       data-ouia-safe="true"
       type="button"
@@ -50,7 +50,7 @@ exports[`Empty renders correctly 1`] = `
       <a
         aria-disabled="false"
         class="pf-c-button pf-m-link"
-        data-ouia-component-id="OUIA-Generated-Button-link-2"
+        data-ouia-component-id="OUIA-Generated-Button-link-1"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         href="#"


### PR DESCRIPTION

# Description

This commit adds description and link to documentation to the landing page when there are no images


Fixes related to issue: https://issues.redhat.com/browse/THEEDGE-3446
before the changes: 
<img width="1229" alt="Screenshot 2023-06-27 at 14 53 33" src="https://github.com/RedHatInsights/edge-frontend/assets/73419853/43abb6aa-c9ff-4246-b7f4-9c4c68ffd5f5">
after the changes:
<img width="1373" alt="Screenshot 2023-06-27 at 14 54 41" src="https://github.com/RedHatInsights/edge-frontend/assets/73419853/8f98cea3-55e1-4574-9149-fcc140f9e14d">


## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted