### PR TITLE
fix fedated link to image details

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -119,6 +119,10 @@ const createRows = (
       deviceBaseUrl !== 'federated'
         ? `${deviceBaseUrl}/${DeviceUUID}`
         : `/${DeviceUUID}`;
+    const pathToImage =
+      deviceBaseUrl !== 'federated'
+        ? `${paths.manageImages}/${ImageSetID}`
+        : `/image-builder/manage-edge-images/${ImageSetID}`;
     return {
       rowInfo: {
         deviceID: DeviceID,
@@ -156,7 +160,7 @@ const createRows = (
           title: ImageName
             ? hasLinks
               ? createLink({
-                  pathname: `${paths.manageImages}/${ImageSetID}`,
+                  pathname: pathToImage,
                   linkText: ImageName,
                   history,
                   navigate,


### PR DESCRIPTION
# Description

This will fix the current error when we click on federated link on inventory
Instead open edge, we'll open the magenage-edge-images/:id under insights

Fixes # (THEEDGE-3458)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted