### PR TITLE
chore: Expose ImagesInformationCard thru prod webpack

### DIFF
--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -27,7 +27,10 @@ plugins.push(
           __dirname,
           '../src/Routes/ImageManagerDetail/ImageDetail.js'
         ),
-
+        './ImagesInformationCard': resolve(
+          __dirname,
+          '../src/components/ImageInformationCard.js'
+        ),
         './DeviceTable': resolve(
           __dirname,
           '../src/Routes/Devices/DeviceTable.js'


### PR DESCRIPTION
# Description

This should make sure we expose the ImagesInformationCard federated module which is required for https://github.com/RedHatInsights/insights-inventory-frontend/pull/1909.

Fixes https://issues.redhat.com/browse/THEEDGE-3359

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted