### PR TITLE
fix link behavior to redirect to image-builder federated details

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -10,6 +10,7 @@ import CustomEmptyState from '../../components/Empty';
 import { createLink, emptyStateNoFilters } from '../../utils';
 import DeviceStatus, { getDeviceStatus } from '../../components/Status';
 import RetryUpdatePopover from './RetryUpdatePopover';
+import { Button } from '@patternfly/react-core';
 
 const defaultFilters = [
   {
@@ -121,8 +122,9 @@ const createRows = (
         : `/${DeviceUUID}`;
     const pathToImage =
       deviceBaseUrl !== 'federated'
-        ? `${paths.manageImages}/${ImageSetID}`
-        : `/image-builder/manage-edge-images/${ImageSetID}`;
+        ? `edge${paths.manageImages}/${ImageSetID}`
+        : `insights/image-builder/manage-edge-images/${ImageSetID}`;
+
     return {
       rowInfo: {
         deviceID: DeviceID,
@@ -157,16 +159,24 @@ const createRows = (
             : DeviceName,
         },
         {
-          title: ImageName
-            ? hasLinks
-              ? createLink({
-                  pathname: pathToImage,
-                  linkText: ImageName,
-                  history,
-                  navigate,
-                })
-              : ImageName
-            : 'unavailable',
+          title: ImageName ? (
+            hasLinks ? (
+              <Button
+                variant="link"
+                target-href={pathToImage}
+                onClick={(e) => {
+                  e.preventDefault();
+                  window.location.href = `${pathToImage}`;
+                }}
+              >
+                {ImageName}
+              </Button>
+            ) : (
+              ImageName
+            )
+          ) : (
+            'unavailable'
+          ),
         },
         {
           title:
@@ -262,7 +272,6 @@ const DeviceTable = ({
     : pathname === '/'
     ? ''
     : `${pathname}/systems`;
-
   const actionResolver = (rowData) => {
     const getUpdatePathname = (updateRowData) =>
       historyProp


### PR DESCRIPTION
# Description

Fix the link to image-details from list of devices.
Now the redirect will open the federated image detail page instead reload the inventory list.
On edge the behavior should be the same.

Fixes # (THEEDGE-3458)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted