### PR TITLE
change the look and feel of empty state

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @resoluteCoder @adeliaferreira @matoval @de1987 @acruzgon @tpapaioa @ldjebran @acosferreira
+* @resoluteCoder @adeliaferreira @matoval @de1987 @acruzgon @ldjebran @acosferreira

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @resoluteCoder @adeliaferreira @matoval @de1987 @acruzgon @tpapaioa @ldjebran
+* @resoluteCoder @adeliaferreira @matoval @de1987 @acruzgon @tpapaioa @ldjebran @acosferreira

--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -11,6 +11,7 @@ import { useLocation, useHistory, useNavigate } from 'react-router-dom';
 import { emptyStateNoFilters } from '../../utils';
 import Status from '../../components/Status';
 import { getBaseURLFromPrefixAndName } from '../ImageManagerDetail/utils';
+import { distributionMapper } from '../../constants';
 
 const TooltipSelectorRef = ({ index }) => (
   <div>
@@ -49,33 +50,47 @@ const columnNames = [
     title: 'Name',
     type: 'name',
     sort: true,
-    columnTransforms: [cellWidth(35)],
+    columnTransforms: [cellWidth(15)],
   },
   {
-    title: 'Current version',
+    title: 'Version',
     type: 'version',
     sort: false,
     columnTransforms: [cellWidth(15)],
   },
   {
-    title: 'Last updated',
-    type: 'updated_at',
-    sort: true,
-    columnTransforms: [cellWidth(25)],
+    title: 'Release',
+    type: 'distribution',
+    options: distributionMapper,
+    sort: false,
+    columnTransforms: [cellWidth(15)],
+  },
+  {
+    title: 'Target',
+    type: 'outputTypes',
+    sort: false,
+    columnTransforms: [cellWidth(15)],
   },
   {
     title: 'Status',
     type: 'status',
     sort: false,
-    columnTransforms: [cellWidth(30)],
+    columnTransforms: [cellWidth(15)],
+  },
+  {
+    title: 'Created/Updated',
+    type: 'updated_at',
+    sort: true,
+    columnTransforms: [cellWidth(35)],
   },
 ];
-
 const createRows = (data, baseURL, history, navigate) => {
   return data.map((image_set, index) => ({
     rowInfo: {
       id: image_set?.ID,
       imageStatus: image_set?.Status,
+      distribution: image_set?.Distribution,
+      outputType: image_set?.OutputTypes,
       isoURL: image_set?.ImageBuildIsoURL || null,
       latestImageID: image_set?.ImageID,
     },
@@ -91,12 +106,11 @@ const createRows = (data, baseURL, history, navigate) => {
 
       image_set?.Version,
       {
-        title: image_set?.UpdatedAt ? (
-          <DateFormat date={image_set?.UpdatedAt} />
-        ) : (
-          'Unknown'
-        ),
+        title: distributionMapper[image_set?.Distribution],
       },
+      image_set?.OutputTypes.length == 2
+        ? 'Bare Metal Installer'
+        : 'Update Only',
       {
         title: (
           <>
@@ -104,6 +118,13 @@ const createRows = (data, baseURL, history, navigate) => {
             <TooltipSelectorRef index={index} />
             <Status type={image_set?.Status.toLowerCase()} />
           </>
+        ),
+      },
+      {
+        title: image_set?.UpdatedAt ? (
+          <DateFormat date={image_set?.UpdatedAt} />
+        ) : (
+          'Unknown'
         ),
       },
     ],
@@ -210,7 +231,7 @@ const ImageTable = ({
           rows={data ? createRows(data, baseURL, history, navigate) : []}
           actionResolver={actionResolver}
           areActionsDisabled={areActionsDisabled}
-          defaultSort={{ index: 2, direction: 'desc' }}
+          defaultSort={{ index: 5, direction: 'desc' }}
           toolbarButtons={[
             {
               title: 'Create new image',

--- a/src/components/general-table/GeneralTable.test.js
+++ b/src/components/general-table/GeneralTable.test.js
@@ -61,7 +61,7 @@ describe('General table', () => {
             emptyStateAction={emptyStateAction}
             actionResolver={actionResolver}
             areActionsDisabled={() => false}
-            defaultSort={{ index: 0, direction: 'desc' }}
+            defaultSort={{ index: 5, direction: 'desc' }}
             toolbarButtons={[
               {
                 title: 'test button',


### PR DESCRIPTION
# Description
this commit fixes the empty state when there are no images at the screen,

Fixes # -related to https://issues.redhat.com/browse/THEEDGE-3478
<img width="1363" alt="Screenshot 2023-07-23 at 18 05 42" src="https://github.com/RedHatInsights/edge-frontend/assets/73419853/d8fe1075-2a98-40d0-a04b-5a8754739460">

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted