### PR TITLE
change the look and feel when there are no images at the screen

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -94,7 +94,7 @@
   margin-right: 10px;
 }
 
-a#build-register-images, a#working-with-systems { 
+a#build-register-images, a#working-with-systems {
   display:none;
 }
 
@@ -104,4 +104,8 @@ a#build-register-images, a#working-with-systems {
 
 .pf-c-description-list__group .pf-c-description-list__term {
   width: fit-content
+}
+
+.edge-stretched-button {
+  margin: 20px
 }

--- a/src/Routes/ImageManager/ImageSetsTable.js
+++ b/src/Routes/ImageManager/ImageSetsTable.js
@@ -140,6 +140,7 @@ const ImageTable = ({
   data,
   count,
   isLoading,
+  docLinkProp,
   hasError,
   fetchImageSets,
   openCreateWizard,
@@ -147,6 +148,10 @@ const ImageTable = ({
   hasModalSubmitted,
   setHasModalSubmitted,
 }) => {
+  const docLink =
+    docLinkProp === undefined
+      ? 'https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index'
+      : docLinkProp;
   const { search } = locationProp
     ? locationProp()
     : useLocation
@@ -202,7 +207,6 @@ const ImageTable = ({
     pathPrefix,
     urlName
   );
-
   return (
     <>
       {emptyStateNoFilters(isLoading, count, search) ? (
@@ -210,21 +214,32 @@ const ImageTable = ({
           data-testid="general-table-empty-state-no-data"
           icon={'plus'}
           title={'Create an OSTree image'}
-          body={
-            'Use the image builder tool to compose ' +
-            'customized RHEL (rpm-ostree) images optimized for Edge.' +
-            ' Then, you can remotely install, and securely manage and' +
-            ' scale deployments of the images on Edge servers.'
-          }
-          primaryAction={{
-            click: openCreateWizard,
-            text: 'Create new image',
-          }}
+          body={[
+            'Image builder is a tool to compose customized RHEL (rpm-ostree) images optimized for Edge. ',
+            'With OSTree, you can manage the system software by referencing a central image repository. ' +
+              'Images contain a complete operating system ready to be remotely installed at scale. ' +
+              'Updates to images are tracked through commits and enable secure updates that only ' +
+              'address changes and keep the operating system unchanged. Image updates are quick, ' +
+              'and rollbacks are easy.',
+          ]}
           secondaryActions={[
             {
               type: 'link',
-              title: 'RHEL for Edge image documentation',
-              link: 'https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index',
+              title: 'Learn more about OSTree.',
+              link: 'https://ostreedev.github.io/ostree/',
+            },
+            {
+              variant: 'primary',
+              className: 'edge-stretched-button',
+              onClick: () => openCreateWizard(),
+              type: 'button',
+              title: 'Create image.',
+            },
+            {
+              type: 'link',
+              iconPosition: 'left',
+              title: 'Image builder for OSTree documentation',
+              link: docLink,
             },
           ]}
         />
@@ -278,6 +293,7 @@ ImageTable.propTypes = {
   }),
   hasModalSubmitted: PropTypes.bool,
   setHasModalSubmitted: PropTypes.func,
+  docLinkProp: PropTypes.string,
 };
 
 export default ImageTable;

--- a/src/Routes/ImageManager/__snapshots__/ImageSetsTable.test.js.snap
+++ b/src/Routes/ImageManager/__snapshots__/ImageSetsTable.test.js.snap
@@ -32,46 +32,97 @@ exports[`ImageSets table to render correctly 1`] = `
     <div
       class="pf-c-empty-state__body"
     >
-      Use the image builder tool to compose customized RHEL (rpm-ostree) images optimized for Edge. Then, you can remotely install, and securely manage and scale deployments of the images on Edge servers.
+      <div>
+        Image builder is a tool to compose customized RHEL (rpm-ostree) images optimized for Edge. 
+        <br />
+        <br />
+      </div>
+      <div>
+        With OSTree, you can manage the system software by referencing a central image repository. Images contain a complete operating system ready to be remotely installed at scale. Updates to images are tracked through commits and enable secure updates that only address changes and keep the operating system unchanged. Image updates are quick, and rollbacks are easy.
+        <br />
+        <br />
+      </div>
     </div>
-    <button
-      aria-disabled="false"
-      class="pf-c-button pf-m-primary"
-      data-ouia-component-id="OUIA-Generated-Button-primary-1"
-      data-ouia-component-type="PF4/Button"
-      data-ouia-safe="true"
-      type="button"
-    >
-      Create new image
-    </button>
     <div
       class="pf-c-empty-state__secondary"
     >
-      <a
-        aria-disabled="false"
-        class="pf-c-button pf-m-link"
-        data-ouia-component-id="OUIA-Generated-Button-link-1"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe="true"
-        href="https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index"
-        target="_blank"
+      <div
+        class="pf-l-stack"
       >
-        RHEL for Edge image documentation
-        <svg
-          aria-hidden="true"
-          class="pf-u-ml-sm"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align: -0.125em;"
-          viewBox="0 0 512 512"
-          width="1em"
+        <div
+          class="pf-l-stack__item"
         >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-          />
-        </svg>
-      </a>
+          <a
+            aria-disabled="false"
+            class="pf-c-button pf-m-link"
+            data-ouia-component-id="OUIA-Generated-Button-link-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            href="https://ostreedev.github.io/ostree/"
+            target="_blank"
+          >
+            Learn more about OSTree.
+            <svg
+              aria-hidden="true"
+              class="pf-u-ml-sm"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              />
+            </svg>
+          </a>
+        </div>
+        <div
+          class="pf-l-stack__item"
+        >
+          <button
+            aria-disabled="false"
+            class="pf-c-button pf-m-primary edge-stretched-button"
+            data-ouia-component-id="OUIA-Generated-Button-primary-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            target=""
+            type="button"
+          >
+            Create image.
+          </button>
+        </div>
+        <div
+          class="pf-l-stack__item"
+        >
+          <a
+            aria-disabled="false"
+            class="pf-c-button pf-m-link"
+            data-ouia-component-id="OUIA-Generated-Button-link-2"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            href="https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index"
+            target="_blank"
+          >
+            Image builder for OSTree documentation
+            <svg
+              aria-hidden="true"
+              class="pf-u-ml-sm"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/Empty.js
+++ b/src/components/Empty.js
@@ -6,6 +6,8 @@ import {
   EmptyStateIcon,
   EmptyStateBody,
   EmptyStateSecondaryActions,
+  Stack,
+  StackItem,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
@@ -25,7 +27,17 @@ const Empty = ({
     <Title headingLevel="h4" size="lg">
       {title}
     </Title>
-    <EmptyStateBody>{body}</EmptyStateBody>
+    <EmptyStateBody>
+      {Array.isArray(body)
+        ? body.map((item, index) => (
+            <div key={index}>
+              {item}
+              <br />
+              <br />
+            </div>
+          ))
+        : body}
+    </EmptyStateBody>
     {primaryAction && (
       <>
         {primaryAction.href ? (
@@ -42,19 +54,26 @@ const Empty = ({
       </>
     )}
     <EmptyStateSecondaryActions>
-      {secondaryActions.map(({ type, title, link, onClick }, index) => (
-        <Button
-          component={type === 'link' ? 'a' : 'button'}
-          href={link}
-          variant="link"
-          target={type === 'link' ? '_blank' : ''}
-          key={index}
-          onClick={onClick}
-        >
-          {title}
-          {link && <ExternalLinkAltIcon className="pf-u-ml-sm" />}
-        </Button>
-      ))}
+      <Stack>
+        {secondaryActions.map(
+          ({ type, title, link, onClick, variant, className }, index) => (
+            <StackItem key={index}>
+              <Button
+                component={type === 'link' ? 'a' : 'button'}
+                className={className}
+                href={link}
+                variant={variant || 'link'}
+                target={type === 'link' ? '_blank' : ''}
+                key={index}
+                onClick={onClick}
+              >
+                {title}
+                {link && <ExternalLinkAltIcon className="pf-u-ml-sm" />}
+              </Button>
+            </StackItem>
+          )
+        )}
+      </Stack>
     </EmptyStateSecondaryActions>
   </EmptyState>
 );

--- a/src/components/__snapshots__/Empty.test.js.snap
+++ b/src/components/__snapshots__/Empty.test.js.snap
@@ -47,31 +47,39 @@ exports[`Empty renders correctly 1`] = `
     <div
       class="pf-c-empty-state__secondary"
     >
-      <a
-        aria-disabled="false"
-        class="pf-c-button pf-m-link"
-        data-ouia-component-id="OUIA-Generated-Button-link-1"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe="true"
-        href="#"
-        target="_blank"
+      <div
+        class="pf-l-stack"
       >
-        Secondary action
-        <svg
-          aria-hidden="true"
-          class="pf-u-ml-sm"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align: -0.125em;"
-          viewBox="0 0 512 512"
-          width="1em"
+        <div
+          class="pf-l-stack__item"
         >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-          />
-        </svg>
-      </a>
+          <a
+            aria-disabled="false"
+            class="pf-c-button pf-m-link"
+            data-ouia-component-id="OUIA-Generated-Button-link-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            href="#"
+            target="_blank"
+          >
+            Secondary action
+            <svg
+              aria-hidden="true"
+              class="pf-u-ml-sm"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Description

this commit fixes the empty state when there are no images at the screen,

Fixes # related to https://issues.redhat.com/browse/THEEDGE-3478
<img width="1363" alt="Screenshot 2023-07-23 at 18 05 42" src="https://github.com/RedHatInsights/edge-frontend/assets/73419853/ed0e2079-3e3a-4866-a31d-07b3eb78b08e">

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted