### PR TITLE
add docLinkProp to Images component

### DIFF
--- a/src/Routes/ImageManager/Images.js
+++ b/src/Routes/ImageManager/Images.js
@@ -29,6 +29,7 @@ const Images = ({
   historyProp,
   locationProp,
   navigateProp,
+  docLinkProp,
   notificationProp,
   showHeaderProp,
 }) => {
@@ -113,6 +114,7 @@ const Images = ({
           isLoading={isLoading}
           hasError={hasError}
           fetchImageSets={fetchImageSets}
+          docLinkProp={docLinkProp}
           openCreateWizard={openCreateWizard}
           openUpdateWizard={openUpdateWizard}
           hasModalSubmitted={hasModalSubmitted}
@@ -189,5 +191,6 @@ Images.propTypes = {
   navigateProp: PropTypes.func,
   notificationProp: PropTypes.object,
   showHeaderProp: PropTypes.bool,
+  docLinkProp: PropTypes.string,
 };
 export default Images;


### PR DESCRIPTION
# Description

This commit add docLinkProp to Images component to give us the ability to see it in image_builder side, 
that exposed images component

Fixes # (https://issues.redhat.com/browse/THEEDGE-3478)
## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted