### PR TITLE
fix: Aligment on inventory table used as federated module

### DIFF
--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -134,6 +134,8 @@ const Inventory = ({ historyProp, locationProp, showHeaderProp }) => {
   if (showHeaderProp !== undefined && showHeader) {
     classNameMain =
       'edge-devices pf-l-page__main-section pf-c-page__main-section';
+  } else if (!showHeader) {
+    classNameMain = 'pf-c-toolbar';
   }
 
   function handleOnSubmitEditName(value) {


### PR DESCRIPTION
# Description

When inventory table is used as federate module, it's missing CSS class to add space in top of table.
Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted