### PR TITLE
fix parameters when link comes from federation

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -119,7 +119,7 @@ const createRows = (
     const pathToDevice =
       deviceBaseUrl !== 'federated'
         ? `${deviceBaseUrl}/${DeviceUUID}`
-        : `/${DeviceUUID}`;
+        : `/insights/inventory/${DeviceUUID}`;
     const pathToImage =
       deviceBaseUrl !== 'federated'
         ? `edge${paths.manageImages}/${ImageSetID}`
@@ -267,7 +267,7 @@ const DeviceTable = ({
     : null;
 
   // Create base URL path for system detail link
-  const deviceBaseUrl = historyProp
+  const deviceBaseUrl = navigateProp
     ? 'federated'
     : pathname === paths.inventory
     ? pathname


### PR DESCRIPTION
# Description

due the support to navigateProp the federate validation was wrong and the detail page and image wasnt working properly.
This fix changes the validation and pass the correct url

![fix-details](https://github.com/RedHatInsights/edge-frontend/assets/5039367/12bac879-d0fa-4f5e-a0d8-dbaba236b257)

Fixes # (THEEDGE-3488)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted