### PR TITLE
fix url behavior

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -117,11 +117,10 @@ const createRows = (
         </Tooltip>
       </div>
     );
-
     const pathToDevice =
       deviceBaseUrl !== 'federated'
-        ? `${deviceBaseUrl}/${DeviceUUID}`
-        : `/insights/inventory/${DeviceUUID}`;
+        ? `edge${paths.inventory}/${DeviceUUID}`
+        : `insights/inventory/${DeviceUUID}`;
     const pathToImage =
       deviceBaseUrl !== 'federated'
         ? `edge${paths.manageImages}/${ImageSetID}`
@@ -155,7 +154,6 @@ const createRows = (
             ? createLink({
                 pathname: pathToDevice,
                 linkText: DeviceName,
-                history,
                 navigate,
               })
             : DeviceName,


### PR DESCRIPTION
# Description

This PR fixes the behavior when we click to open the system details on federated tab or edge link
fixes the URL parameters and what was preventing to keep the `/preview`
Edge
![THEEDGE-3557-1](https://github.com/RedHatInsights/edge-frontend/assets/5039367/030c0ae5-e062-444d-a54e-531104a19e36)

inventory
![THEEDGE-3557-2](https://github.com/RedHatInsights/edge-frontend/assets/5039367/f69f1288-c6b3-4436-83d4-a836136301b0)

Fixes # (THEEDGE-3557)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `npm run lint:js:fix` to check that my code is properly formatted