### PR TITLE
devices-view: display inventory device group.

### DIFF
--- a/src/Routes/GroupsDetail/GroupsDetail.test.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.test.js
@@ -6,6 +6,8 @@ import { render } from '@testing-library/react';
 import { init, RegistryContext } from '../../store';
 import logger from 'redux-logger';
 
+jest.mock('../../utils');
+
 describe('Groups', () => {
   it('should render correctly', () => {
     const registry = init(logger);


### PR DESCRIPTION
# Description
- Display inventory device group returned from back-en when feature flag "edgeParity.inventory-groups-enabled" is enabled.
- Mock utils module in GroupsDetail.test.js as the test trying to use the feature flag and fail. 

FiXES: https://issues.redhat.com/browse/THEEDGE-3580

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted