### PR TITLE
THEEDGE-3602-fix path to correct screen when go back to System

### DIFF
--- a/src/Routes/Devices/UpdateSystem.js
+++ b/src/Routes/Devices/UpdateSystem.js
@@ -404,7 +404,9 @@ const UpdateSystem = ({
             <BreadcrumbItem>
               {createLink({
                 pathname:
-                  currentInventoryPath === 'edge' ? '/' : currentInventoryPath,
+                  currentInventoryPath === 'edge'
+                    ? `${currentInventoryPath}/inventory`
+                    : `insights${currentInventoryPath}/manage-edge-inventory`,
                 linkText: 'Systems',
                 history,
               })}


### PR DESCRIPTION
Fixes # https://issues.redhat.com/browse/THEEDGE-3602
this commit fix a bug when user open update system screen and want to go back to Systems screen

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted