### PR TITLE
fix path to correct screen when pressing on Host name

### DIFF
--- a/src/Routes/Devices/UpdateSystem.js
+++ b/src/Routes/Devices/UpdateSystem.js
@@ -415,7 +415,7 @@ const UpdateSystem = ({
               {createLink({
                 pathname:
                   currentInventoryPath === 'edge'
-                    ? `${currentInventoryPath}/${currentId}/`
+                    ? `${currentInventoryPath}/inventory/${currentId}/`
                     : `insights${currentInventoryPath}/${currentId}`,
                 linkText: device?.DeviceName || <Skeleton width="100px" />,
                 history,


### PR DESCRIPTION
FIXES # https://issues.redhat.com/browse/THEEDGE-3603 
this commit fix the path to correct screen, when user press on Host name, in Edge application

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted