### PR TITLE
Add feature flag control over group actions

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -288,6 +288,11 @@ const DeviceTable = ({
     : pathname === '/'
     ? ''
     : `${pathname}/systems`;
+
+  const groupActionsEnabled = useFeatureFlags(
+    'edge-management.hide_groups_actions'
+  );
+
   const actionResolver = (rowData) => {
     const getUpdatePathname = (updateRowData) =>
       navigateProp
@@ -297,7 +302,7 @@ const DeviceTable = ({
     if (isLoading) return actions;
     if (!rowData?.rowInfo?.id) return actions;
 
-    if (handleAddDevicesToGroup) {
+    if (handleAddDevicesToGroup && groupActionsEnabled) {
       actions.push({
         title: 'Add to group',
         onClick: () =>
@@ -347,7 +352,7 @@ const DeviceTable = ({
       });
     }
 
-    if (handleRemoveDevicesFromGroup) {
+    if (handleRemoveDevicesFromGroup && groupActionsEnabled) {
       actions.push({
         title: 'Remove from group',
         isDisabled: rowData?.rowInfo?.deviceGroups.length === 0,

--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -18,6 +18,7 @@ import { editDisplayName, deleteEntity } from '../../store/actions';
 import { useDispatch } from 'react-redux';
 import apiWithToast from '../../utils/apiWithToast';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useFeatureFlags } from '../../utils';
 
 const UpdateDeviceModal = React.lazy(() =>
   import(/* webpackChunkName: "UpdateDeviceModal" */ './UpdateDeviceModal')
@@ -227,6 +228,9 @@ const Inventory = ({
     chrome?.updateDocumentTitle?.('Systems - Inventory | Edge management');
   }, [chrome]);
 
+  const groupActionsEnabled = useFeatureFlags(
+    'edge-management.hide_groups_actions'
+  );
   return (
     <>
       {showHeader && (
@@ -255,20 +259,24 @@ const Inventory = ({
           hasCheckbox={true}
           selectedItems={setCheckedDeviceIds}
           selectedItemsUpdateable={canBeUpdated()}
-          kebabItems={[
-            {
-              isDisabled: !(checkedDeviceIds.length > 0),
-              title: 'Add to group',
-              onClick: () =>
-                handleAddDevicesToGroup(
-                  checkedDeviceIds.map((device) => ({
-                    ID: device.deviceID,
-                    name: device.display_name,
-                  })),
-                  false
-                ),
-            },
-          ]}
+          kebabItems={
+            groupActionsEnabled
+              ? [
+                  {
+                    isDisabled: !(checkedDeviceIds.length > 0),
+                    title: 'Add to group',
+                    onClick: () =>
+                      handleAddDevicesToGroup(
+                        checkedDeviceIds.map((device) => ({
+                          ID: device.deviceID,
+                          name: device.display_name,
+                        })),
+                        false
+                      ),
+                  },
+                ]
+              : undefined
+          }
           hasModalSubmitted={hasModalSubmitted}
           setHasModalSubmitted={setHasModalSubmitted}
           fetchDevices={fetchDevices}


### PR DESCRIPTION
# Description

This will add a feature flag control over the group actions on the edge management inventory screen

Fixes # 3577

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted