### PR TITLE
inventory-groups: implement build remove systems from inventory group.

### DIFF
--- a/src/Routes/Devices/RemoveDeviceModal.js
+++ b/src/Routes/Devices/RemoveDeviceModal.js
@@ -103,22 +103,35 @@ const RemoveDeviceModal = ({
       ? values.group.toString()
       : deviceGroups[0].Name;
     const groupId = hasManyGroups ? values.group.groupId : deviceGroups[0].ID;
+    const systemText =
+      deviceInfo.length > 1
+        ? `${deviceInfo.length} systems`
+        : deviceInfo[0].name;
+
+    const errorMessageDescription = inventoryGroupsEnabled
+      ? deviceInfo.length > 1
+        ? `Failed to remove ${deviceInfo.length} systems from ${groupName}`
+        : `Failed to remove 1 system from ${groupName}`
+      : 'Failed to remove system from group';
 
     const statusMessages = {
       onSuccess: {
         title: 'Success',
-        description: `${deviceInfo[0].name} has been removed from ${groupName} successfully`,
+        description: `${systemText} has been removed from ${groupName} successfully`,
       },
       onError: {
         title: 'Error',
-        description: 'Failed to remove system from group',
+        description: errorMessageDescription,
       },
     };
 
     let removeDeviceGroupFunc;
     if (inventoryGroupsEnabled) {
       removeDeviceGroupFunc = () =>
-        removeDevicesFromInventoryGroup(groupId, [deviceInfo[0].UUID]);
+        removeDevicesFromInventoryGroup(
+          groupId,
+          deviceInfo.map((device) => device.UUID)
+        );
     } else {
       removeDeviceGroupFunc = () =>
         removeDeviceFromGroupById(groupId, deviceInfo[0].ID);


### PR DESCRIPTION
# Description

implement remove edge systems from inventory group in the system's kebab action.
- Bulk Remove systems to group from systems table.
- Disable bulk remove from group when one of the selected systems has no group assigned.
- Disable bulk remove when the selected systems belong to different groups.
- The Remove from group menu item is shown only when inventory-groups feature flag is enabled.
- Tested to work in federated mode and in edge 
 
FIXES: https://issues.redhat.com/browse/THEEDGE-3579

![build-remove-systems-from-groups](https://github.com/RedHatInsights/edge-frontend/assets/131553/67ac88cc-0436-4696-8473-7f7c8476d970)


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted