### PR TITLE
enable params to filter device table based on group uuid

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -558,6 +558,7 @@ DeviceTable.propTypes = {
   isSystemsView: PropTypes.bool,
   isAddSystemsView: PropTypes.bool,
   urlName: PropTypes.string,
+  groupUUID: PropTypes.string,
 };
 
 export default DeviceTable;

--- a/src/Routes/Devices/DevicesView.js
+++ b/src/Routes/Devices/DevicesView.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import DeviceTable from './DeviceTable';
 import useApi from '../../hooks/useApi';
-import { getInventory } from '../../api/devices';
+import PropTypes from 'prop-types';
+import { getInventory, getInventoryByGroup } from '../../api/devices';
 
 const DevicesView = (props) => {
   const [response, fetchDevices] = useApi({
-    api: getInventory,
+    api: props?.groupUUID ? getInventoryByGroup : getInventory,
+    id: props?.groupUUID ? props?.groupUUID.toString() : '',
     tableReload: true,
   });
   const { data, isLoading, hasError } = response;
@@ -20,6 +22,10 @@ const DevicesView = (props) => {
       {...props}
     />
   );
+};
+
+DevicesView.propTypes = {
+  groupUUID: PropTypes.string,
 };
 
 export default DevicesView;

--- a/src/api/devices/index.js
+++ b/src/api/devices/index.js
@@ -6,6 +6,10 @@ export const getInventory = ({ query }) => {
   return instance.get(`${EDGE_API}/devices/devicesview?${q}`);
 };
 
+export const getInventoryByGroup = ({ id, query }) => {
+  const q = getTableParams(query);
+  return instance.get(`${EDGE_API}/devices/devicesview?${q}&groupUUID=${id}`);
+};
 export const getDevice = (id) => {
   return instance.get(`${EDGE_API}/devices/${id}`);
 };


### PR DESCRIPTION
# Description

enable prop to filter device table based on groupUUID and immutable hosts on group details

![image](https://github.com/RedHatInsights/edge-frontend/assets/5039367/aa324a55-21e8-4091-a093-3a29fa510ea7)


Fixes # (THEEDGE-3581)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted