### PR TITLE
Fix table align removing padding from button link

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -10,7 +10,6 @@ import CustomEmptyState from '../../components/Empty';
 import { createLink, emptyStateNoFilters, useFeatureFlags } from '../../utils';
 import DeviceStatus, { getDeviceStatus } from '../../components/Status';
 import RetryUpdatePopover from './RetryUpdatePopover';
-import { Button } from '@patternfly/react-core';
 import {
   FEATURE_HIDE_GROUP_ACTIONS,
   FEATURE_PARITY_INVENTORY_GROUPS,
@@ -178,16 +177,7 @@ const createRows = (
         {
           title: ImageName ? (
             hasLinks ? (
-              <Button
-                variant="link"
-                target-href={pathToImage}
-                onClick={(e) => {
-                  e.preventDefault();
-                  window.location.href = `${pathToImage}`;
-                }}
-              >
-                {ImageName}
-              </Button>
+              <a href={pathToImage}>{ImageName}</a>
             ) : (
               ImageName
             )

--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -175,15 +175,15 @@ const createRows = (
             : DeviceName,
         },
         {
-          title: ImageName ? (
-            hasLinks ? (
-              <a href={pathToImage}>{ImageName}</a>
-            ) : (
-              ImageName
-            )
-          ) : (
-            'unavailable'
-          ),
+          title: ImageName
+            ? hasLinks
+              ? createLink({
+                  pathname: pathToImage,
+                  linkText: ImageName,
+                  navigate,
+                })
+              : ImageName
+            : 'unavailable',
         },
         {
           title:

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -117,6 +117,7 @@ export const getReleases = (forcedRelease, inculdedReleases) =>
 export const createLink = ({ pathname, linkText, target }) => {
   return (
     <Button
+      style={{ '--pf-c-button--PaddingLeft': '0' }}
       component="a"
       target={target}
       variant="link"


### PR DESCRIPTION
# Description

This PR will solve an alignment issue that initially was reported on System table, but affects image Table too. This was solve removing a unnecessary component on Devices Table and add a css override inside our create link utils method.

Fixes #THEEDGE-3599

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted