### PR TITLE
THEEDGE-3619-remove update option when comming from group

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -381,7 +381,7 @@ const DeviceTable = ({
       });
     }
 
-    if (!areActionsDisabled(rowData)) {
+    if (!areActionsDisabled(rowData) && handleUpdateSelected) {
       actions.push({
         title: 'Update',
         onClick: (_event, _rowId, rowData) => {


### PR DESCRIPTION
this commit fix a bug when user open system list from specific group, and update option appear there.
the fix remove this update option


https://github.com/RedHatInsights/edge-frontend/assets/73419853/23769800-df52-445a-83ee-4d01c3f409cf





# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # THEEDGE-3619 

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted