### PR TITLE
THEEDGE-3632: add data validation to show sort option on deviceTable

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -34,12 +34,12 @@ const defaultFilters = [
   },
 ];
 
-const GetColumnNames = (inventoryGroupsEnabled) => {
+const GetColumnNames = (inventoryGroupsEnabled, isDataAvailable) => {
   return [
     {
       title: 'Name',
       type: 'name',
-      sort: true,
+      sort: isDataAvailable,
       columnTransforms: [cellWidth(30)],
     },
     {
@@ -57,7 +57,7 @@ const GetColumnNames = (inventoryGroupsEnabled) => {
     {
       title: 'Last seen',
       type: 'last_seen',
-      sort: true,
+      sort: isDataAvailable,
       columnTransforms: [cellWidth(15)],
     },
     {
@@ -411,8 +411,8 @@ const DeviceTable = ({
   // some filters and columns titles/labels have different values when shown in insights inventory
   let tableFilters = [];
   let tableColumnNames = [];
-
-  const columnNames = GetColumnNames(inventoryGroupsEnabled);
+  const isDataAvailable = data ? data.length > 0 : false;
+  const columnNames = GetColumnNames(inventoryGroupsEnabled, isDataAvailable);
 
   if (urlName === insightsInventoryManageEdgeUrlName) {
     for (let ind = 0; ind < defaultFilters.length; ind++) {


### PR DESCRIPTION
# Description

Add validation around if data is available on device table to show or not the ordering options on table column title.

Fixes # THEEDGE-3632

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted