### PR TITLE
group-details: add enforce-edge-groups to groups-view

### DIFF
--- a/src/Routes/GroupsDetail/GroupsDetail.js
+++ b/src/Routes/GroupsDetail/GroupsDetail.js
@@ -271,6 +271,7 @@ const GroupsDetail = () => {
             setHasModalSubmitted={setHasModalSubmitted}
             fetchDevices={fetchDevices}
             isAddSystemsView={true}
+            enforceEdgeGroups={data?.DevicesView?.enforce_edge_groups}
           />
         ) : (
           <Flex justifyContent={{ default: 'justifyContentCenter' }}>


### PR DESCRIPTION
# Description
when an is enforced to use edge-groups the edge groups was not displayed inventory group was displayed instead. this fix this behavior on the front end. a backend PR is following.

FIXES: https://issues.redhat.com/browse/THEEDGE-3552


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted