### PR TITLE
add support to rhel-89 and rhel-93

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -66,15 +66,19 @@ export const distributionMapper = {
   'rhel-86': 'RHEL 8.6',
   'rhel-87': 'RHEL 8.7',
   'rhel-88': 'RHEL 8.8',
+  'rhel-89': 'RHEL 8.9',
   'rhel-90': 'RHEL 9.0',
   'rhel-91': 'RHEL 9.1',
   'rhel-92': 'RHEL 9.2',
+  'rhel-93': 'RHEL 9.3',
 };
 
 export const releaseMapper = {
+  'rhel-93': 'Red Hat Enterprise Linux (RHEL) 9.3',
   'rhel-92': 'Red Hat Enterprise Linux (RHEL) 9.2',
   'rhel-91': 'Red Hat Enterprise Linux (RHEL) 9.1',
   'rhel-90': 'Red Hat Enterprise Linux (RHEL) 9.0',
+  'rhel-89': 'Red Hat Enterprise Linux (RHEL) 8.9',
   'rhel-88': 'Red Hat Enterprise Linux (RHEL) 8.8',
   'rhel-87': 'Red Hat Enterprise Linux (RHEL) 8.7',
   'rhel-86': 'Red Hat Enterprise Linux (RHEL) 8.6',
@@ -88,15 +92,17 @@ export const supportedReleases = [
   'rhel-86',
   'rhel-87',
   'rhel-88',
+  'rhel-89',
   'rhel-90',
   'rhel-91',
   'rhel-92',
+  'rhel-93',
 ];
 
-export const temporaryReleases = ['rhel-92'];
+export const temporaryReleases = ['rhel-93'];
 
-export const DEFAULT_RELEASE = 'rhel-92';
-export const TEMPORARY_RELEASE = 'rhel-92';
+export const DEFAULT_RELEASE = 'rhel-93';
+export const TEMPORARY_RELEASE = 'rhel-93';
 
 export const imageTypeMapper = {
   'rhel-edge-commit': 'RHEL for Edge Commit (.tar)',


### PR DESCRIPTION
# Description
this commit add support for 2 distibution.
FIX # THEEDGE-3742





https://github.com/RedHatInsights/edge-frontend/assets/73419853/edef2a46-9dda-4940-a4ab-d0b1976c90c8





## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `npm run lint:js:fix` to check that my code is properly formatted