### PR TITLE
device-details: add routes to cards modals views.

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -94,6 +94,7 @@ export const Routes = () => {
           component={UpdateSystem}
         />
         <Route path={paths.inventoryDetail} component={DeviceDetail} />
+        <Route path={paths.inventoryDetailModal} component={DeviceDetail} />
         <Route path={paths.manageImagesDetailVersion} component={ImageDetail} />
         <Route path={paths.manageImagesDetail} component={ImageDetail} />
         <Route path={paths.manageImages} component={Images} />

--- a/src/constants/routeMapper.js
+++ b/src/constants/routeMapper.js
@@ -11,6 +11,7 @@ export const routes = {
   inventory: '/inventory',
   insightsInventory: '/insights/inventory/manage-edge-inventory',
   inventoryDetail: '/inventory/:deviceId',
+  inventoryDetailModal: '/inventory/:deviceId/:modalId',
   inventoryDetailUpdate: '/inventory/:deviceId/update',
   insightsInventoryDetailUpdate: '/insights/inventory/:deviceId/update',
   manageImages: '/manage-images',


### PR DESCRIPTION
# Descriptio

This Fixes and allow to navigate from url to the model view in device details cards 

FIXES: https://issues.redhat.com/browse/THEEDGE-3764

Note: an other PR will be submitted to inventory front.  but this should not be a blocker for this PR

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted


![navigate-to-device-view-cards-model-view](https://github.com/RedHatInsights/edge-frontend/assets/131553/51933523-6fa8-4360-af28-e9f8a8b4932d)

