### PR TITLE
update: fixes systems text when updating one device

### DIFF
--- a/src/Routes/Devices/UpdateDeviceModal.js
+++ b/src/Routes/Devices/UpdateDeviceModal.js
@@ -85,7 +85,7 @@ const UpdateDeviceModal = ({
       title: 'Updating system',
       description: isMultiple
         ? ` ${deviceName.length} systems were added to the queue.`
-        : ` ${deviceName} was added to the queue.`,
+        : ` ${deviceName ? deviceName : 'one system'}  was added to the queue.`,
     },
     onError: {
       title: 'Error',
@@ -148,8 +148,8 @@ const UpdateDeviceModal = ({
         <span className="pf-u-font-weight-bold pf-u-font-size-md">
           {isMultiple
             ? `${deviceName.length} systems`
-            : inventoryGroupUpdateDevicesInfo
-            ? '1 system'
+            : inventoryGroupUpdateDevicesInfo || !deviceName
+            ? 'one system'
             : deviceName}
         </span>{' '}
         to latest version of the image linked to it.


### PR DESCRIPTION
# Description

When updating one device from a selection, especially from inventory groups, the deviceName may be unknown from the given data 

FIXES: https://issues.redhat.com/browse/THEEDGE-3782

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted


When used when deviceName is known 

![image](https://github.com/RedHatInsights/edge-frontend/assets/131553/1536d15a-e22f-4ff0-886f-a766137b6536)

When used when device Name is unknown 

![image](https://github.com/RedHatInsights/edge-frontend/assets/131553/0bc97637-e998-4488-b6a3-7f6aa08b2b71)



