### PR TITLE
systems-detail: enable delete system

### DIFF
--- a/src/Routes/DeviceDetail/DeviceDetail.js
+++ b/src/Routes/DeviceDetail/DeviceDetail.js
@@ -159,6 +159,7 @@ const DeviceDetail = () => {
         )}
         <InventoryDetailHead
           fallback=""
+          showDelete={true}
           actions={[
             {
               title: 'Update',


### PR DESCRIPTION
# Description
System delete button was not enabled in edge systems details, this PR enable delete button in InventoryDetailsHead.

FIXES: https://issues.redhat.com/browse/THEEDGE-3801

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted

[Screencast from 2024-01-12 12-35-04.webm](https://github.com/RedHatInsights/edge-frontend/assets/131553/9d23ceb2-e4e5-4fc5-98d0-542f21cb2eaa)


