### PR TITLE
groups: fixes groups error displayed

### DIFF
--- a/src/Routes/Devices/AddDeviceModal.js
+++ b/src/Routes/Devices/AddDeviceModal.js
@@ -63,7 +63,7 @@ const AddDeviceModal = ({
 }) => {
   const dispatch = useDispatch();
 
-  const inventoryGroupsEnabled = useInventoryGroups(false);
+  const [inventoryGroupsEnabled] = useInventoryGroups(false);
 
   const handleAddDevices = (values) => {
     const { group } = values;

--- a/src/Routes/Devices/RemoveDeviceModal.js
+++ b/src/Routes/Devices/RemoveDeviceModal.js
@@ -86,7 +86,7 @@ const RemoveDeviceModal = ({
 }) => {
   const dispatch = useDispatch();
 
-  const inventoryGroupsEnabled = useInventoryGroups(false);
+  const [inventoryGroupsEnabled] = useInventoryGroups(false);
 
   const { deviceGroups } = deviceInfo[0];
 

--- a/src/Routes/Groups/CreateGroupModal.js
+++ b/src/Routes/Groups/CreateGroupModal.js
@@ -77,7 +77,7 @@ const CreateGroupModal = ({
 }) => {
   const dispatch = useDispatch();
 
-  const inventoryGroupsEnabled = useInventoryGroups(false);
+  const [inventoryGroupsEnabled] = useInventoryGroups(false);
 
   const handleCreateGroup = (values) => {
     const statusMessages = {

--- a/src/Routes/Groups/Groups.js
+++ b/src/Routes/Groups/Groups.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Flex } from '@patternfly/react-core';
+import { Bullseye, Flex, Spinner } from '@patternfly/react-core';
 import {
   PageHeader,
   PageHeaderTitle,
@@ -22,7 +22,9 @@ const Groups = ({ locationProp, navigateProp, paramsProp }) => {
   const hideCreateGroupsEnabled = useFeatureFlags(
     'edge-management.hide-create-group'
   );
-  const inventoryGroupsEnabled = useInventoryGroups(false);
+  const [inventoryGroupsEnabled, enforceEdgeGroupCheckReady] =
+    useInventoryGroups(false);
+
   const { search } = locationProp ? locationProp() : useLocation();
 
   const [response, fetchGroups] = useApi({
@@ -59,7 +61,11 @@ const Groups = ({ locationProp, navigateProp, paramsProp }) => {
 
   return (
     <>
-      {inventoryGroupsEnabled ? (
+      {!enforceEdgeGroupCheckReady ? (
+        <Bullseye>
+          <Spinner size="xl" />
+        </Bullseye>
+      ) : inventoryGroupsEnabled ? (
         <GroupsLinkAccess />
       ) : (
         <>

--- a/src/Routes/Groups/Groups.test.js
+++ b/src/Routes/Groups/Groups.test.js
@@ -7,6 +7,7 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import { RegistryContext } from '../../store';
 
 jest.mock('../../utils');
+jest.mock('../../hooks/useInventoryGroups', () => () => [false, true]);
 
 describe('Groups', () => {
   const mockStore = configureStore();

--- a/src/components/SearchInputApi.js
+++ b/src/components/SearchInputApi.js
@@ -14,7 +14,7 @@ import useInventoryGroups from '../hooks/useInventoryGroups';
 
 const SelectInput = (props) => {
   useFieldApi(props);
-  const inventoryGroupsEnabled = useInventoryGroups(false);
+  const [inventoryGroupsEnabled] = useInventoryGroups(false);
 
   const { change } = useFormApi();
   const [isOpen, setIsOpen] = useState(false);

--- a/src/hooks/useInventoryGroups.js
+++ b/src/hooks/useInventoryGroups.js
@@ -5,6 +5,7 @@ import { getEnforceEdgeGroups } from '../api/groups';
 
 const useInventoryGroups = (value) => {
   const [data, setData] = useState(value);
+  const [ready, setReady] = useState(false);
   const inventoryGroupsEnabled = useFeatureFlags(
     FEATURE_PARITY_INVENTORY_GROUPS
   );
@@ -14,10 +15,11 @@ const useInventoryGroups = (value) => {
       const response = await getEnforceEdgeGroups();
       const enforceEdgeGroups = response?.enforce_edge_groups;
       setData(!enforceEdgeGroups && inventoryGroupsEnabled);
+      setReady(true);
     })();
   }, []);
 
-  return data;
+  return [data, ready];
 };
 
 export default useInventoryGroups;


### PR DESCRIPTION
# Description
We are returning 501 from the api when inventory-groups is enabled and the user is not from and enforced edge group org. This PR prevent doing api call to groups before enforceEdgeGroups check finished.

FIXES: https://issues.redhat.com/browse/THEEDGE-3856

tested to work with special and simple org

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted