### PR TITLE
device-table: preserve devices filters across pages

### DIFF
--- a/src/Routes/Devices/DeviceTable.js
+++ b/src/Routes/Devices/DeviceTable.js
@@ -464,6 +464,7 @@ const DeviceTable = ({
             apiFilterSort={true}
             isUseApi={true}
             filters={tableFilters}
+            filtersName={'edge-devices-table-filters'}
             loadTableData={fetchDevices}
             tableData={{
               count: count,

--- a/src/components/general-table/GeneralTable.js
+++ b/src/components/general-table/GeneralTable.js
@@ -52,6 +52,7 @@ const GeneralTable = ({
   apiFilterSort,
   urlParam,
   filters,
+  filtersName,
   loadTableData,
   tableData,
   columnNames,
@@ -77,8 +78,32 @@ const GeneralTable = ({
   isFooterFixed = false,
 }) => {
   const defaultCheckedRows = initSelectedItems ? initSelectedItems : [];
-  const [filterValues, setFilterValues] = useState(createFilterValues(filters));
+  const initialFilterValues = createFilterValues(filters);
+  const [filterValues, setFilterValues] = useState(initialFilterValues);
+
+  useEffect(() => {
+    if (filtersName) {
+      const sessionFilterValue = window.sessionStorage.getItem(filtersName);
+      if (sessionFilterValue) {
+        const initialFilter = JSON.parse(sessionFilterValue);
+        setFilterValues(initialFilter);
+      }
+    }
+  }, [filtersName]);
+
   const [chipsArray, setChipsArray] = useState([]);
+
+  useEffect(() => {
+    if (filtersName) {
+      if (chipsArray.length === 0) {
+        window.sessionStorage.removeItem(filtersName);
+      } else {
+        const val = JSON.stringify(filterValues);
+        window.sessionStorage.setItem(filtersName, val);
+      }
+    }
+  }, [filtersName, filterValues, chipsArray]);
+
   const [sortBy, setSortBy] = useState(defaultSort);
   const [perPage, setPerPage] = useState(50);
   const [page, setPage] = useState(1);
@@ -324,8 +349,7 @@ const GeneralTable = ({
                     : [
                         {
                           title: 'Clear all filters',
-                          onClick: () =>
-                            setFilterValues(createFilterValues(filters)),
+                          onClick: () => setFilterValues(initialFilterValues),
                         },
                       ]
                 }
@@ -435,6 +459,7 @@ GeneralTable.propTypes = {
   navigateProp: PropTypes.func,
   apiFilterSort: PropTypes.bool,
   filters: PropTypes.array,
+  filtersName: PropTypes.string,
   urlParam: PropTypes.string,
   loadTableData: PropTypes.func,
   tableData: PropTypes.object,


### PR DESCRIPTION
# Description

The only way that I found to preserve filters across pages and application federated/non federated is to use window.sessionStorage.

 FIXES: https://issues.redhat.com/browse/THEEDGE-3799

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `npm run lint:js:fix` to check that my code is properly formatted


[Screencast from 2024-02-16 11-45-56.webm](https://github.com/RedHatInsights/edge-frontend/assets/131553/bf144dd1-6b70-4287-9b94-168ce095a8f2)


