### PR TITLE
fix(HMS-4325): rename ramaining groups to workspaces

### DIFF
--- a/src/Routes/Groups/GroupsLinkAccess.js
+++ b/src/Routes/Groups/GroupsLinkAccess.js
@@ -36,8 +36,9 @@ const GroupsLinkAccess = () => {
           Groups have moved
         </Title>
         <EmptyStateBody id="moved-state-body">
-          You can now use your groups across the console. Access them on the
-          Insights {useWorkspacesRename ? 'Workspaces' : 'Groups'} page.
+          You can now use your {useWorkspacesRename ? 'workspaces' : 'groups'}{' '}
+          across the console. Access them on the Insights{' '}
+          {useWorkspacesRename ? 'Workspaces' : 'Groups'} page.
         </EmptyStateBody>
         <Button
           id="moved-state-button"


### PR DESCRIPTION
# Description

Rename remaining groups references to workspaces

Fixes [# (HMS-4325)](https://issues.redhat.com/browse/HMS-4325)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
