### PR TITLE
fix(HMS-4609): filter by name regression

### DIFF
--- a/src/components/general-table/FilterInput.js
+++ b/src/components/general-table/FilterInput.js
@@ -13,7 +13,7 @@ const FilterInput = ({ filterValues, setFilterValues, input }) => {
   const selectedFilter = filterValues.find((filter) => filter.label === input);
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleFilterChange = () => (value, checkboxValue) => {
+  const handleFilterChange = () => (event, checkboxValue) => {
     setFilterValues((prevState) => {
       const selectedIndex = prevState.findIndex(
         (filter) => filter.label === selectedFilter.label
@@ -32,7 +32,7 @@ const FilterInput = ({ filterValues, setFilterValues, input }) => {
           isChecked: !checkedType?.value[checkboxIndex]?.isChecked,
         },
       });
-      const newTextValue = value;
+      const newTextValue = event?.target?.value;
 
       return Object.values({
         ...prevState,


### PR DESCRIPTION
# Description

Fixing filter images by name, the PF5 search input uses the event and not value as the first argument.

https://github.com/user-attachments/assets/89d1a79d-3dda-45d0-9d12-3f9c4496577b



Fixes # (issue)
HMS-4609
## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
