### PR TITLE
fix(HMS-4710): output iso checkbox

### DIFF
--- a/src/components/form/ImageOutputCheckbox.js
+++ b/src/components/form/ImageOutputCheckbox.js
@@ -35,11 +35,11 @@ const ImageOutputCheckbox = (props) => {
   const { getState } = useFormApi();
   const { input } = useFieldApi(props);
   const toggleCheckbox = useCallback(
-    (checked, event) => {
+    (event, checked) => {
       input.onChange(
         checked
-          ? [...input.value, event.currentTarget.id]
-          : input.value.filter((item) => item !== event.currentTarget.id)
+          ? [...input.value, event.target.id]
+          : input.value.filter((item) => item !== event.target.id)
       );
     },
     [input.onChange]


### PR DESCRIPTION
# Description

iso checkbox couldn't be selected, caused by a PF5 change in the checkbox `onChange` callback args

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
