### PR TITLE
add RHEL 8.10 to distribution mapper

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -67,6 +67,7 @@ export const distributionMapper = {
   'rhel-87': 'RHEL 8.7',
   'rhel-88': 'RHEL 8.8',
   'rhel-89': 'RHEL 8.9',
+  'rhel-8.10': 'RHEL 8.10',
   'rhel-90': 'RHEL 9.0',
   'rhel-91': 'RHEL 9.1',
   'rhel-92': 'RHEL 9.2',


### PR DESCRIPTION
# Description

Adds RHEL 8.10 text to image list based on distribution mapping

Fixes # HMS-5418

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
