### PR TITLE
fix(RHINENG-16672): Change appName to scope for AsyncComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "nightly": "npm run deploy",
     "start": "fec dev",
     "start:proxy": "PROXY=true fec dev",
+    "static": "fec static",
     "start:federated": "BETA=true fec static -p 8002",
     "test": "TZ=UTC jest --verbose --no-cache",
     "verify": "npm-run-all build lint test",

--- a/src/Routes/DeviceDetail/Vulnerability.js
+++ b/src/Routes/DeviceDetail/Vulnerability.js
@@ -160,7 +160,7 @@ const VulnerabilityTab = ({
       <section className="add-100vh pf-l-page__main-section pf-c-page__main-section">
         {alerts[activeAlert]}
         <AsyncComponent
-          appName="vulnerability"
+          scope="vulnerability"
           module="./SystemDetail"
           getRegistry={getRegistry}
           customIntlProvider

--- a/src/Routes/Devices/Inventory.js
+++ b/src/Routes/Devices/Inventory.js
@@ -30,11 +30,11 @@ const UpdateDeviceModal = React.lazy(() =>
 );
 
 const TextInputModal = (props) => (
-  <AsyncComponent appName="inventory" module="./TextInputModal" {...props} />
+  <AsyncComponent scope="inventory" module="./TextInputModal" {...props} />
 );
 
 const DeleteModal = (props) => (
-  <AsyncComponent appName="inventory" module="./DeleteModal" {...props} />
+  <AsyncComponent scope="inventory" module="./DeleteModal" {...props} />
 );
 
 const Inventory = ({

--- a/src/components/DeviceDetail.js
+++ b/src/components/DeviceDetail.js
@@ -9,7 +9,7 @@ import CmpLoader from './CmpLoader';
 
 const GeneralInformation = (props) => (
   <AsyncComponent
-    appName="inventory"
+    scope="inventory"
     module="./GeneralInformation"
     fallback={<CmpLoader numberOfRows={3} />}
     {...props}
@@ -18,7 +18,7 @@ const GeneralInformation = (props) => (
 
 const SystemCard = (props) => (
   <AsyncComponent
-    appName="inventory"
+    scope="inventory"
     module="./SystemCard"
     fallback={<CmpLoader numberOfRows={5} />}
     {...props}
@@ -27,7 +27,7 @@ const SystemCard = (props) => (
 
 const OperatingSystemCard = (props) => (
   <AsyncComponent
-    appName="inventory"
+    scope="inventory"
     module="./OperatingSystemCard"
     fallback={<CmpLoader numberOfRows={6} />}
     {...props}
@@ -36,7 +36,7 @@ const OperatingSystemCard = (props) => (
 
 const BiosCard = (props) => (
   <AsyncComponent
-    appName="inventory"
+    scope="inventory"
     module="./BiosCard"
     fallback={<CmpLoader numberOfRows={4} />}
     {...props}
@@ -45,7 +45,7 @@ const BiosCard = (props) => (
 
 const CollectionCard = (props) => (
   <AsyncComponent
-    appName="inventory"
+    scope="inventory"
     module="./CollectionCard"
     fallback={<CmpLoader numberOfRows={7} />}
     {...props}
@@ -54,7 +54,7 @@ const CollectionCard = (props) => (
 
 const InfrastructureCard = (props) => (
   <AsyncComponent
-    appName="inventory"
+    scope="inventory"
     module="./InfrastructureCard"
     fallback={<CmpLoader numberOfRows={6} />}
     {...props}

--- a/src/components/ImageCreator.js
+++ b/src/components/ImageCreator.js
@@ -25,8 +25,7 @@ import CustomPackageTextArea from './form/CustomPackageTextArea';
  */
 export const AsyncCreateImageWizard = (props) => (
   <AsyncComponent
-    appName="image-builder"
-    scope="image_builder"
+    scope="image-builder"
     module="./ImageCreator"
     fallback={<Spinner />}
     {...props}

--- a/src/components/ImageInformationCard.js
+++ b/src/components/ImageInformationCard.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 
 const LoadingCard = (props) => (
   <AsyncComponent
-    appName="inventory"
+    scope="inventory"
     module="./LoadingCard"
     fallback={<CmpLoader numberOfRows={5} />}
     {...props}


### PR DESCRIPTION
# Description

Fixes https://issues.redhat.com/browse/RHINENG-16672.

This fixes the bug when federated modules could not be loaded because of the incorrect passing of scope param to AsyncComponent.

To test, try to open any view that utilises AsyncComponent (loads a federated module) and make sure the view does not crash.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
