### PR TITLE
fix: Fix spacing of Image status column

### DIFF
--- a/src/Routes/Devices/RetryUpdatePopover.js
+++ b/src/Routes/Devices/RetryUpdatePopover.js
@@ -28,8 +28,8 @@ const popoverDescription = (reason, status, lastSeen) => (
       : status === UNRESPONSIVE
       ? 'The service could not be reached via RHC. The system may communicate at a later time if this is a network issue or could be an indication of a more significant problem.'
       : 'Unknown'}
-    <Stack className="pf-u-mt-sm">
-      <StackItem className="pf-u-font-weight-bold">Last seen</StackItem>
+    <Stack className="pf-v5-u-mt-sm">
+      <StackItem className="pf-v5-u-font-weight-bold">Last seen</StackItem>
       <StackItem> {<DateFormat date={lastSeen} />}</StackItem>
     </Stack>
   </div>
@@ -78,8 +78,7 @@ const RetryUpdatePopover = ({
           alertseverityvariant="danger"
           headerContent={
             <div style={{ color: '#c9190b' }}>
-              {' '}
-              <ExclamationCircleIcon size="sm" />
+              <ExclamationCircleIcon size="sm" className="pf-v5-u-mr-xs" />
               {popoverTitle(device.DispatcherReason, device.DispatcherStatus)}
             </div>
           }

--- a/src/Routes/ImageManagerDetail/__snapshots__/DetailsHeader.test.js.snap
+++ b/src/Routes/ImageManagerDetail/__snapshots__/DetailsHeader.test.js.snap
@@ -27,7 +27,7 @@ exports[`DetailsHeader renders correctly 1`] = `
             style="color: rgb(62, 134, 53);"
           >
             <div
-              class="pf-v5-l-split__item pf-u-mr-sm"
+              class="pf-v5-l-split__item pf-v5-u-mr-xs"
             >
               <svg
                 aria-hidden="true"

--- a/src/components/Status.js
+++ b/src/components/Status.js
@@ -39,9 +39,9 @@ const Status = ({
         </Label>
       ) : (
         <Split id={id} style={{ color }} className={className}>
-          <SplitItem className="pf-u-mr-sm">
+          <SplitItem className="pf-v5-u-mr-xs">
             {toolTipContent ? (
-              <Tooltip content="blargh">
+              <Tooltip content={toolTipContent}>
                 <Icon />
               </Tooltip>
             ) : (


### PR DESCRIPTION
- Column content has spacer between icon and label
- Add spacer between icon and popover header
- "Last seen" in popover is bold and has top margin
- `toolTipContent` is not used, but I fixed it if someone would use it in the future

## Before
![Screenshot From 2025-05-09 11-42-16](https://github.com/user-attachments/assets/ce619e7a-5049-4d52-b918-1604b195c182)

## After
![Screenshot From 2025-05-09 11-39-03](https://github.com/user-attachments/assets/5e14092d-d628-49f4-af81-5ce69bf57954)