### PR TITLE
Move decomissioning banner app-wide

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,15 @@ import { notificationsReducer } from '@redhat-cloud-services/frontend-components
 import { NotificationPortal } from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import './App.scss';
 import AuthModal from './components/AuthModal';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import {
+  Alert,
+  Bullseye,
+  Button,
+  Spinner,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const App = (props) => {
   const { getRegistry } = useContext(RegistryContext);
@@ -38,9 +46,41 @@ const App = (props) => {
     };
   }, []);
 
+  const RHEM_DOCUMENTATION_URL =
+    'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/managing_device_fleets_with_the_red_hat_edge_manager/index';
+
   return (
     <Fragment>
       <NotificationPortal />
+      <Alert
+        variant="info"
+        isInline
+        title={<>Upcoming decommission of hosted Edge Management service</>}
+        className="pf-v5-u-mt-sm pf-v5-u-mb-sm"
+      >
+        <TextContent>
+          <Text>
+            As of July 31, 2025, the hosted edge management service will no
+            longer be supported. This means that pushing image updates to
+            Immutable (OSTree) systems using the Hybrid Cloud Console will be
+            discontinued For an alternative way to manage edge systems,
+            customers are encouraged to explore Red Hat Edge Manager (RHEM).
+          </Text>
+          <Text>
+            <Button
+              component="a"
+              target="_blank"
+              variant="link"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="right"
+              isInline
+              href={RHEM_DOCUMENTATION_URL}
+            >
+              Red Hat Edge Manager (RHEM) documentation
+            </Button>
+          </Text>
+        </TextContent>
+      </Alert>
       {isAuth && isLogged ? (
         <Routes childProps={props} />
       ) : isAuth === null ? (

--- a/src/Routes/Repositories/RepositoryLinkAccess.js
+++ b/src/Routes/Repositories/RepositoryLinkAccess.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Alert,
   Button,
   EmptyState,
   EmptyStateIcon,
@@ -15,9 +14,6 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import PageHeader from '@redhat-cloud-services/frontend-components/PageHeader';
 
-const RHEM_DOCUMENTATION_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/managing_device_fleets_with_the_red_hat_edge_manager/index';
-
 const RepositoryLinkAccess = () => (
   <>
     <PageHeader>
@@ -27,36 +23,6 @@ const RepositoryLinkAccess = () => (
         </Text>
       </TextContent>
     </PageHeader>
-    <Alert
-      variant="info"
-      isInline
-      title={<>Upcoming decommission of hosted Edge Management service</>}
-      className="pf-v5-u-mt-sm pf-v5-u-mb-sm"
-    >
-      <TextContent>
-        <Text>
-          As of July 31, 2025, the hosted edge management service will no longer
-          be supported. This means that pushing image updates to Immutable
-          (OSTree) systems using the Hybrid Cloud Console will be discontinued.
-          For an alternative way to manage edge systems, customers are
-          encouraged to explore Red Hat Edge Manager (RHEM).
-        </Text>
-        <Text>
-          <Button
-            component="a"
-            target="_blank"
-            variant="link"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="right"
-            isInline
-            href={RHEM_DOCUMENTATION_URL}
-          >
-            Red Hat Edge Manager (RHEM) documentation
-          </Button>
-        </Text>
-      </TextContent>
-    </Alert>
-
     <EmptyState id="moved-state">
       <EmptyStateHeader
         titleText="Custom repositories have moved"


### PR DESCRIPTION
# Description

The previous pr just had the banner on the repos page, this makes it app wide.

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
